### PR TITLE
feat!(pds-ember): add Link styles

### DIFF
--- a/.yarn/versions/19c1aecd.yml
+++ b/.yarn/versions/19c1aecd.yml
@@ -1,0 +1,2 @@
+releases:
+  "@hashicorp/pds-ember": minor

--- a/packages/pds-ember/addon/components/pds/link/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/link/docs.mdx
@@ -1,0 +1,42 @@
+import { Props } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / Link';
+
+# Link
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+No Ember assets are available.
+
+Continue reading to learn how to apply semantic markup and styling.
+
+
+## Styling
+```scss
+@use "pds/components/link";
+```
+
+
+## Markup
+Use a semantic hyperlink (i.e., any element that matches the
+[`:any-link` pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:any-link).
+
+```html
+<a href="{URL}" ...attributes>
+  Read More
+</a>
+```
+
+
+## Accessibility
+* Hyperlinks cannot be semantically disabled via HTML attribute configuration.
+* The simplest way to prevent a user from navigating via a link is to avoid
+  rendering the link at all.
+
+## See Also
+TBD...

--- a/packages/pds-ember/addon/components/pds/link/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/link/stories/index.stories.js
@@ -1,0 +1,78 @@
+import hbs from 'htmlbars-inline-precompile';
+import DocsPage, { TITLE } from '../docs.mdx';
+
+const CONFIG = {
+  title: TITLE,
+  parameters: { docs: { page: DocsPage } },
+};
+
+const Index = () => ({
+  template: hbs`
+    <a href="#">
+      Read More
+    </a>
+  `,
+});
+
+const Hover = () => ({
+  template: hbs`
+    <a href="#" class="mock-hover">
+      Read More
+    </a>
+  `,
+});
+
+const Focus = () => ({
+  template: hbs`
+    <a href="#" class="mock-focus">
+      Read More
+    </a>
+  `,
+});
+
+const FocusHover = () => ({
+  template: hbs`
+    <a href="#" class="mock-focus mock-hover">
+      Read More
+    </a>
+  `,
+});
+
+const Active = () => ({
+  template: hbs`
+    <a href="#" class="mock-active">
+      Read More
+    </a>
+  `,
+});
+
+const WithLeadingIcon = () => ({
+  template: hbs`
+    <a href="#">
+      <Pds::Icon @type="info-circle-fill" />
+      Read More
+    </a>
+  `
+});
+
+const WithTrailingIcon = () => ({
+  template: hbs`
+    <a href="#">
+      Read More
+      <Pds::Icon @type="exit" />
+    </a>
+  `
+});
+
+export {
+  CONFIG as default,
+  Index,
+
+  Hover,
+  Focus,
+  FocusHover,
+  Active,
+
+  WithLeadingIcon,
+  WithTrailingIcon,
+}

--- a/packages/pds-ember/app/styles/pds/components/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/index.scss
@@ -7,6 +7,7 @@
 @use "help-text";
 @use "icon";
 @use "input";
+@use "link";
 @use "modal";
 @use "select";
 @use "sidebar";

--- a/packages/pds-ember/app/styles/pds/components/link/_config.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/_config.scss
@@ -1,0 +1,75 @@
+$_module: "PDS.Components.Link";
+@use "sass:map";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../config" as Component;
+@use "../../theme";
+@use "../../tokens/typography" as Typography;
+@use "../../utils/pseudo" as Pseudo;
+
+@mixin theme($styles) {
+  /* [debug] #{$_module}@theme */
+  @include Component.theme(link, $styles);
+}
+
+@mixin reset {
+  @include Typography.reset;
+}
+
+// :any-link
+$DEFAULT: (
+  boxShadow: none,
+  color: theme.$action-base,
+  borderBottomColor: transparent,
+);
+// :any-link:hover
+$HOVER: (
+  borderBottomColor: currentcolor,
+);
+// :any-link:focus
+$FOCUS: map.merge($HOVER, (
+  boxShadow: theme.$boxShadow--focus,
+));
+// :any-link:active
+$ACTIVE: map.merge($HOVER, (
+  boxShadow: none,
+  color: theme.$action-d1,
+));
+
+:root {
+  @include theme($DEFAULT);
+}
+
+// Themable Properties
+$boxShadow: var(--pds-link-boxShadow);
+$color: var(--pds-link-color);
+$borderBottomColor: var(--pds-link-borderBottomColor);
+
+
+@mixin appearance {
+  /* [debug] #{$_module}@appearance */
+  box-shadow: $boxShadow;
+  color: $color;
+  cursor: pointer;
+  text-decoration: none;
+  border-bottom: 1px solid $borderBottomColor;
+
+  @include Pseudo.hover {
+    @include theme($HOVER);
+  }
+
+  @include Pseudo.focus {
+    @include theme($FOCUS);
+    outline: none;
+  }
+
+  @include Pseudo.active {
+    @include theme($ACTIVE);
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  :any-link {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/link/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/index.scss
@@ -1,0 +1,11 @@
+@use "config" as *;
+
+// Default (:any-link)
+@include apply {
+  @include reset;
+  @include appearance;
+}
+
+// Variants
+// TODO: underlined // :any-link.pds--underlined
+// TODO: subtle     // :any-link.pds--subtle

--- a/packages/pds-ember/app/styles/pds/core/_links.scss
+++ b/packages/pds-ember/app/styles/pds/core/_links.scss
@@ -1,5 +1,0 @@
-@use "../theme";
-
-a[href] {
-  color: theme.$action-base;
-}

--- a/packages/pds-ember/app/styles/pds/core/index.scss
+++ b/packages/pds-ember/app/styles/pds/core/index.scss
@@ -1,2 +1,1 @@
-@use "links";
 @use "typography";

--- a/packages/pds-ember/app/styles/pds/tokens/_typography.scss
+++ b/packages/pds-ember/app/styles/pds/tokens/_typography.scss
@@ -143,3 +143,9 @@ $LINE_HEIGHTS: (
   font-weight: Font.weight(Medium);
   line-height: map-get($LINE_HEIGHTS, default);
 }
+
+@mixin reset {
+  /* [debug] #{$_module}@reset */
+  font: inherit;
+  line-height: inherit;
+}


### PR DESCRIPTION
Add default link styles per PDS-154.

## Screenshots

### Default
![link - default](https://user-images.githubusercontent.com/545605/95274905-abce8400-080c-11eb-86bf-d1226a83b080.png)
![link - leading icon - default](https://user-images.githubusercontent.com/545605/95274930-bc7efa00-080c-11eb-86ef-23b13814ada8.png)
![link - trailing icon - default](https://user-images.githubusercontent.com/545605/95274929-bc7efa00-080c-11eb-9855-acbba81b53c1.png)

### Hover
![link - hover](https://user-images.githubusercontent.com/545605/95274908-aec97480-080c-11eb-856b-4d00f510b549.png)
![link - leading icon - hover](https://user-images.githubusercontent.com/545605/95274928-bc7efa00-080c-11eb-8b85-57192844b960.png)
![link - trailing icon - hover](https://user-images.githubusercontent.com/545605/95274926-bbe66380-080c-11eb-98d9-3120d39ab32c.png)

### Focus
![link - focus](https://user-images.githubusercontent.com/545605/95274912-b12bce80-080c-11eb-8318-634084f9fe64.png)

### Focus + Hover
![link - focus + hover](https://user-images.githubusercontent.com/545605/95274917-b5f08280-080c-11eb-9f24-32b4855157c2.png)

### Active
![link - active](https://user-images.githubusercontent.com/545605/95274922-b852dc80-080c-11eb-824a-46951a8b12b8.png)



## 🚨 Breaking Change

* `pds/core` (Sass) no longer includes core Link styles. Use `pds/components/link` instead.