### PR TITLE
dev(pds-ember): update pkg scripts for Storybook via Netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .storybook/preview-head.html
 dist
 tmp*
+storybook-static
 
 # dependencies
 bower_components

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -31,7 +31,7 @@
     "g:component": "ember g pds-component",
     "d:component": "ember d pds-component",
     "storybook": "start-storybook -p 6006 -s dist",
-    "storybook:build": "build-storybook"
+    "build-storybook": "ember build && build-storybook -s dist -o storybook-static"
   },
   "dependencies": {
     "broccoli-funnel": "^3.0.3",


### PR DESCRIPTION
If all goes well, Netlify should deploy Storybook docs to a PR-specific deploy preview URL.

Once this PR is merged, Netlify will deploy up-to-date Storybook docs for every commit to the `master` branch.
Docs will live at https://hashicorp-structure.netlify.app

![CleanShot 2020-10-12 at 16 00 27](https://user-images.githubusercontent.com/545605/95789942-10259380-0ca4-11eb-8355-d268019f71a8.png)
