### PR TITLE
fix(pds-ember): build production Ember assets for Storybook

### DIFF
--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -31,7 +31,7 @@
     "g:component": "ember g pds-component",
     "d:component": "ember d pds-component",
     "storybook": "start-storybook -p 6006 -s dist",
-    "build-storybook": "ember build && build-storybook -s dist -o storybook-static"
+    "build-storybook": "yarn build && build-storybook -s dist -o storybook-static"
   },
   "dependencies": {
     "broccoli-funnel": "^3.0.3",


### PR DESCRIPTION
`ember build` generates development assets by default.  Updating to use the `build` script which runs `ember build` in the production environment.

**BEFORE** (Netlify build log)
![CleanShot 2020-10-12 at 17 20 15](https://user-images.githubusercontent.com/545605/95795138-40266400-0caf-11eb-9aa4-c910264237f0.png)


**AFTER** (Netlify build log)
![CleanShot 2020-10-12 at 17 20 56](https://user-images.githubusercontent.com/545605/95795164-4d435300-0caf-11eb-94a4-14a064fc819a.png)


## Acceptance Criteria
* Navigate to [this PR's deploy preview](https://deploy-preview-19--hashicorp-structure.netlify.app/?path=/story/components-button--index)
* When inspecting PDS component markup, `[data-test-*]` attrs should not be present.