### PR TITLE
fix(pds-ember): correct line height of Pds::Select component

### DIFF
--- a/packages/pds-ember/app/styles/pds/components/select/_config.scss
+++ b/packages/pds-ember/app/styles/pds/components/select/_config.scss
@@ -22,6 +22,7 @@ $height: theme.$control-height;
   display: grid;
   grid-template-columns: 1fr;
   grid-template-rows: $height;
+  line-height: 1;
 
   > * {
     grid-column: 1;

--- a/packages/pds-ember/app/styles/pds/components/select/_control/_config.scss
+++ b/packages/pds-ember/app/styles/pds/components/select/_control/_config.scss
@@ -24,6 +24,7 @@ $padding--inline: theme.$size--sm; // ~12px
   color: custom.$color;
   font-family: $fontFamily;
   font-size: $fontSize;
+  line-height: inherit;
   width: 100%;
 
   @include Pseudo.focus {

--- a/packages/pds-ember/tests/dummy/app/components/docs/form-field/select.hbs
+++ b/packages/pds-ember/tests/dummy/app/components/docs/form-field/select.hbs
@@ -19,6 +19,10 @@
     <option value="Dewey">Dewey</option>
     <option value="Cheetum">Cheetum</option>
     <option value="Enhowe">Enhowe</option>
+    <option value="pangram">
+      The quick brown fox<br />
+      jumps over the lazy dog.
+    </option>
   </Pds::Select>
 
   {{#if @isInvalid}}


### PR DESCRIPTION
`<select>` and `<Pds::Icon>` vertical alignment is being affected by their `line-height` (both of which are larger than `1`, so they have extra whitespace above their content, shifting elements and characters downward

### BEFORE
![select - before](https://user-images.githubusercontent.com/545605/97463426-bb258680-190d-11eb-8a42-66b108070677.png)

### AFTER
![select - after](https://user-images.githubusercontent.com/545605/97463445-bfea3a80-190d-11eb-9baa-ff06a461f3bf.png)