### PR TITLE
fix(pds-ember): correct loading icon fill

### DIFF
--- a/packages/pds-ember/app/styles/pds/components/loading/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/loading/index.scss
@@ -36,6 +36,7 @@
 
     svg path {
       stroke-width: 9%; // FIXME: magic number
+      fill: none;
     }
   }
 


### PR DESCRIPTION
Closes #36

### BEFORE
![loading icon - before](https://user-images.githubusercontent.com/545605/97635705-c8be3780-1a05-11eb-8d0b-3d06fa817599.png)


### AFTER
![loading icon - after](https://user-images.githubusercontent.com/545605/97635703-c825a100-1a05-11eb-8dfa-b625aaf1d884.png)
