### PR TITLE
fix(pds-ember): correct Safari styles of Select component

### DIFF
--- a/packages/pds-ember/app/styles/pds/components/select/_control/_config.scss
+++ b/packages/pds-ember/app/styles/pds/components/select/_control/_config.scss
@@ -1,6 +1,7 @@
 $_module: "PDS.Components.Select._Control";
 /* --- [debug] CONFIG: #{$_module} --- */
 @use "../../../theme";
+@use "../../../utils/property" as Prop;
 @use "../../../utils/pseudo" as Pseudo;
 @use "../_custom";
 
@@ -16,7 +17,7 @@ $padding--inline: theme.$size--sm; // ~12px
 
 // @protected
 @mixin appearance {
-  appearance: none;
+  @include Prop.appearance(none);
   background-color: custom.$backgroundColor;
   border-radius: custom.$borderRadius;
   border: custom.$borderWidth solid transparent;

--- a/packages/pds-ember/app/styles/pds/utils/_property.scss
+++ b/packages/pds-ember/app/styles/pds/utils/_property.scss
@@ -1,0 +1,9 @@
+$_module: "PDS.Utils.Property";
+/// mixins for vendor-prefixed properties
+
+// See https://developer.mozilla.org/en-US/docs/Web/CSS/appearance
+@mixin appearance($value) {
+  /* [debug] #{$_module}@appearance($value) */
+  -webkit-appearance: $value; // Safari
+          appearance: $value; // compliant browsers
+}


### PR DESCRIPTION
Closes #35

### BEFORE
![select - safari - before](https://user-images.githubusercontent.com/545605/97636684-79790680-1a07-11eb-9fd9-5d5b6426ac05.png)


### AFTER
![select - safari - after](https://user-images.githubusercontent.com/545605/97636682-78e07000-1a07-11eb-9bc6-5d81783d2fc3.png)
