### PR TITLE
fix(pds-ember): correct npm dependencies

### DIFF
--- a/.yarn/versions/1f7677d8.yml
+++ b/.yarn/versions/1f7677d8.yml
@@ -1,0 +1,2 @@
+releases:
+  "@hashicorp/pds-ember": prerelease

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -34,21 +34,22 @@
     "build-storybook": "ember build && build-storybook -s dist -o storybook-static"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^1.0.2",
+    "@hashicorp/structure-icons": "1.9.0-0",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-string-utils": "^1.1.0",
+    "ember-intl": "^5.5.0",
     "ember-svg-jar": "^2.2.3",
     "sass": "^1.26.11"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
-    "@ember/render-modifiers": "^1.0.2",
     "@glimmer/component": "^1.0.1",
     "@glimmer/tracking": "^1.0.1",
-    "@hashicorp/structure-icons": "1.9.0-0",
     "@storybook/addon-docs": "^6.0.22",
     "@storybook/addon-essentials": "^6.0.26",
     "@storybook/addon-knobs": "^6.0.22",
@@ -65,7 +66,6 @@
     "ember-cli-terser": "^4.0.0",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.1",
-    "ember-intl": "^5.5.0",
     "ember-load-initializers": "^2.1.1",
     "ember-maybe-import-regenerator": "^0.1.6",
     "ember-qunit": "^4.6.0",

--- a/packages/pds-ember/tests/dummy/config/ember-intl.js
+++ b/packages/pds-ember/tests/dummy/config/ember-intl.js
@@ -47,7 +47,7 @@ module.exports = function(/* environment */) {
      * @type {Boolean}
      * @default "false"
      */
-    wrapTranslationsWithNamespace: true,
+    wrapTranslationsWithNamespace: false,
 
     /**
      * Cause a build error if ICU argument mismatches are detected between translations

--- a/packages/pds-ember/translations/en-us.yaml
+++ b/packages/pds-ember/translations/en-us.yaml
@@ -1,0 +1,5 @@
+pds:
+  components:
+    breadcrumbs:
+      aria:
+        label: breadcrumbs

--- a/packages/pds-ember/translations/pds/components/en-us.yaml
+++ b/packages/pds-ember/translations/pds/components/en-us.yaml
@@ -1,3 +1,0 @@
-breadcrumbs:
-  aria:
-    label: breadcrumbs


### PR DESCRIPTION
- update translations to work with default ember-intl config
  - specifically `wrapTranslationsWithNamespace: false`
- move specific `devDependencies` to `dependencies`
  - `@hashicorp/structure-icons`
    - required by several components that use `<Pds::Icon>` in their template
  - `ember-intl`
    - required by `<Pds::Breadcrumbs>` for `[aria-label]` (and more components to come)
  - `@ember/render-modifiers`
    - required by `<Pds::Loading::Elapsed>` to add/remove timer functionality