### PR TITLE
Add ButtonSet, PageHeader, and Page components

### DIFF
--- a/packages/pds-ember/addon/components/pds/app/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/app/stories/index.stories.js
@@ -22,13 +22,62 @@ export const Index = (args) => ({
   template: hbs`
     <Pds::App @showDrawer={{showDrawer}} as |App|>
       <App.Banner></App.Banner>
-      <App.Header>Header</App.Header>
+
+      <App.Header>
+        App Header
+      </App.Header>
+
       <App.Sidebar>
         <Docs::Nav />
       </App.Sidebar>
-      <App.Body>Body</App.Body>
-      <App.Footer>Footer</App.Footer>
-      <App.Drawer>Drawer</App.Drawer>
+
+      <App.Body>
+        <Pds::Page as |Page|>
+          <Page.Header @variant="filled" as |H|>
+            <H.Breadcrumbs>
+              <Docs::Breadcrumbs
+                @depth={{3}}
+                @showIcon={{true}}
+              />
+            </H.Breadcrumbs>
+
+            <H.Title>
+              Page Title
+            </H.Title>
+
+            <H.Actions>
+              <Pds::ButtonSet>
+                <Pds::Button @variant="primary">
+                  Primary
+                </Pds::Button>
+                <Pds::Dropdown @align="right" as |D|>
+                  <D.Trigger>Secondary</D.Trigger>
+                  <D.Dialog>
+                    <Docs::ContentSkeleton />
+                  </D.Dialog>
+                </Pds::Dropdown>
+              </Pds::ButtonSet>
+            </H.Actions>
+
+            <H.Tabs>
+              <Docs::TabNav />
+            </H.Tabs>
+          </Page.Header>
+
+          <Page.Body>
+            {{! TODO: demonstrate some body content }}
+            Page body
+          </Page.Body>
+        </Pds::Page>
+      </App.Body>
+
+      <App.Footer>
+        App Footer
+      </App.Footer>
+
+      <App.Drawer>
+        App Drawer
+      </App.Drawer>
     </Pds::App>
   `,
   context: args,

--- a/packages/pds-ember/addon/components/pds/button-set/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/button-set/docs.mdx
@@ -1,0 +1,42 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / ButtonSet';
+
+# ButtonSet
+Provides consistent layout and spacing of buttons.
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+
+```handlebars
+<Pds::ButtonSet>
+  <Pds::Button>...</Pds::Button>
+  <Pds::Dropdown>...</Pds::Dropdown>
+  ...
+</Pds::ButtonSet>
+```
+<ArgsTable of="PdsButtonSet" />
+
+
+## Styling
+```scss
+@use "pds/components/button-set";
+```
+
+
+## Markup
+The `<Pds::ButtonSet>` Ember component handles generation of semantic markup.
+
+
+## Accessibility
+TBD...
+
+
+## See Also
+- [Button](?path=/docs/components-button--index)
+- [Dropdown](?path=/docs/components-dropdown--index)

--- a/packages/pds-ember/addon/components/pds/button-set/index.hbs
+++ b/packages/pds-ember/addon/components/pds/button-set/index.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-buttonSet"
+  ...attributes
+  data-test-button-set
+>
+  {{ yield }}
+</div>

--- a/packages/pds-ember/addon/components/pds/button-set/index.js
+++ b/packages/pds-ember/addon/components/pds/button-set/index.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component'
+
+/**
+ * @class PdsButtonSet
+ */
+export default class PdsButtonSet extends Component {}

--- a/packages/pds-ember/addon/components/pds/button-set/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/button-set/stories/index.stories.js
@@ -1,0 +1,31 @@
+import hbs from 'htmlbars-inline-precompile'
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: TITLE,
+  component: 'PdsButtonSet',
+  parameters: { docs: { page: DocsPage } },
+}
+
+export const Index = (args) => ({
+  template: hbs`
+    <Pds::ButtonSet>
+      <Pds::Button @variant="primary">
+        Primary
+      </Pds::Button>
+
+      <Pds::Button>
+        Secondary
+      </Pds::Button>
+
+      <Pds::Button @variant="warning">
+        Warning
+      </Pds::Button>
+
+      <Pds::Button @variant="ghost">
+        Ghost
+      </Pds::Button>
+    </Pds::ButtonSet>
+  `,
+  context: args,
+})

--- a/packages/pds-ember/addon/components/pds/button/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/button/docs.mdx
@@ -141,5 +141,5 @@ in the block template will be wrapped in a `<span>`, when rendered.
 
 
 ## See Also
-TBD...
+- [ButtonSet](?path=/docs/components-buttonset--index)
 

--- a/packages/pds-ember/addon/components/pds/dropdown/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/dropdown/docs.mdx
@@ -65,7 +65,8 @@ markup for a non-modal, dropdown dialog.
 
 
 ## See Also
-- [Dropdown::Trigger](?path=/docs/components-dropdown-trigger--index)
 - [Button (disabled)](?path=/story/components-button-states--disabled)
+- [ButtonSet](?path=/docs/components-buttonset--index)
+- [Dropdown::Trigger](?path=/docs/components-dropdown-trigger--index)
 - [WAI-ARIA Authoring Practices: Dialog (Modal)](https://www.w3.org/TR/wai-aria-practices/#dialog_modal)
     - Similar behavior applies to _non-modal_ dialogs, as well.

--- a/packages/pds-ember/addon/components/pds/page-header/actions.hbs
+++ b/packages/pds-ember/addon/components/pds/page-header/actions.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-pageHeader__actions"
+  ...attributes
+  data-test-page-header-actions
+>
+  {{yield}}
+</div>

--- a/packages/pds-ember/addon/components/pds/page-header/breadcrumbs.hbs
+++ b/packages/pds-ember/addon/components/pds/page-header/breadcrumbs.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-pageHeader__breadcrumbs"
+  ...attributes
+  data-test-page-header-breadcrumbs
+>
+  {{yield}}
+</div>

--- a/packages/pds-ember/addon/components/pds/page-header/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/page-header/docs.mdx
@@ -1,0 +1,44 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / PageHeader';
+
+# PageHeader
+Provides components for constistent Page Header layout and appearance.
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+
+```handlebars
+<Pds::PageHeader as |H|>
+  <H.Breadcrumbs>...</H.Breadcrumbs>
+  <H.Title>...</H.Title>
+  <H.Actions>...</H.Actions>
+  <H.Tabs>...</H.Tabs>
+</Pds::PageHeader>
+```
+* All subcomponents are wrappers for their respective content.
+
+<ArgsTable of="PdsPageHeader" />
+
+
+## Styling
+```scss
+@use "pds/components/page-header";
+```
+
+
+## Markup
+The `<Pds::PageHeader>` and its subcomponents handle generation of semantic markup.
+
+
+## Accessibility
+TBD...
+
+
+## See Also
+- [Page](?path=/docs/components-page--index)

--- a/packages/pds-ember/addon/components/pds/page-header/index.hbs
+++ b/packages/pds-ember/addon/components/pds/page-header/index.hbs
@@ -1,0 +1,15 @@
+<div
+  class="
+    pds-pageHeader
+    {{this.variantClass}}
+  "
+  ...attributes
+  data-test-page-header
+>
+  {{ yield (hash
+    Actions=(component 'pds/page-header/actions')
+    Breadcrumbs=(component 'pds/page-header/breadcrumbs')
+    Tabs=(component 'pds/page-header/tabs')
+    Title=(component 'pds/page-header/title')
+  )}}
+</div>

--- a/packages/pds-ember/addon/components/pds/page-header/index.js
+++ b/packages/pds-ember/addon/components/pds/page-header/index.js
@@ -1,0 +1,24 @@
+import Component from '@glimmer/component'
+
+/**
+ * @class PdsPageHeader
+ */
+
+/**
+ * Valid values:
+ *
+ *   - undefined (a.k.a., "plain")
+ *   - `filled`
+ *
+ * @argument variant
+ * @type {string}
+ */
+export default class PdsPageHeader extends Component {
+  get variantClass() {
+    let { variant } = this.args
+    if (variant) {
+      return `pds--${variant}`
+    }
+    return ''
+  }
+}

--- a/packages/pds-ember/addon/components/pds/page-header/stories/0_index.stories.js
+++ b/packages/pds-ember/addon/components/pds/page-header/stories/0_index.stories.js
@@ -1,0 +1,41 @@
+import hbs from 'htmlbars-inline-precompile'
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: TITLE,
+  component: 'PdsPageHeader',
+  parameters: { docs: { page: DocsPage } },
+  argTypes: {
+    variant: {
+      defaultValue: '',
+      control: {
+        type: 'radio',
+        options: {
+          'plain (default)': '',
+          'filled': 'filled',
+        },
+      },
+    },
+  },
+  args: {
+    variant: '',
+  },
+}
+
+export const Index = (args) => ({
+  template: hbs`
+    <Pds::PageHeader @variant={{variant}} as |H|>
+      <H.Breadcrumbs>
+        <Docs::Breadcrumbs
+          @depth={{3}}
+          @showIcon={{true}}
+        />
+      </H.Breadcrumbs>
+
+      <H.Title>
+        Page Title
+      </H.Title>
+    </Pds::PageHeader>
+  `,
+  context: args,
+})

--- a/packages/pds-ember/addon/components/pds/page-header/stories/1_patterns.stories.js
+++ b/packages/pds-ember/addon/components/pds/page-header/stories/1_patterns.stories.js
@@ -1,0 +1,76 @@
+import hbs from 'htmlbars-inline-precompile'
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: `${TITLE} / Patterns`,
+  component: 'PdsPageHeader',
+  parameters: { docs: { page: DocsPage } },
+}
+
+export const WithActions = (args) => ({
+  template: hbs`
+    <Pds::PageHeader @variant="filled" as |H|>
+      <H.Breadcrumbs>
+        <Docs::Breadcrumbs
+          @depth={{3}}
+          @showIcon={{true}}
+        />
+      </H.Breadcrumbs>
+
+      <H.Title>
+        Page Title
+      </H.Title>
+
+      <H.Actions>
+        <Pds::ButtonSet>
+          <Pds::Button @variant="primary">
+            Primary
+          </Pds::Button>
+          <Pds::Dropdown @align="right" as |D|>
+            <D.Trigger>Secondary</D.Trigger>
+            <D.Dialog>
+              <Docs::ContentSkeleton />
+            </D.Dialog>
+          </Pds::Dropdown>
+        </Pds::ButtonSet>
+      </H.Actions>
+    </Pds::PageHeader>
+  `,
+  context: args,
+})
+
+export const WithActionsAndTabs = (args) => ({
+  template: hbs`
+    <Pds::PageHeader @variant="filled" as |H|>
+      <H.Breadcrumbs>
+        <Docs::Breadcrumbs
+          @depth={{3}}
+          @showIcon={{true}}
+        />
+      </H.Breadcrumbs>
+
+      <H.Title>
+        Page Title
+      </H.Title>
+
+      <H.Actions>
+        <Pds::ButtonSet>
+          <Pds::Button @variant="primary">
+            Primary
+          </Pds::Button>
+          <Pds::Dropdown @align="right" as |D|>
+            <D.Trigger>Secondary</D.Trigger>
+            <D.Dialog>
+              <Docs::ContentSkeleton />
+            </D.Dialog>
+          </Pds::Dropdown>
+        </Pds::ButtonSet>
+      </H.Actions>
+
+      <H.Tabs>
+        <Docs::TabNav />
+      </H.Tabs>
+    </Pds::PageHeader>
+  `,
+  context: args,
+})

--- a/packages/pds-ember/addon/components/pds/page-header/tabs.hbs
+++ b/packages/pds-ember/addon/components/pds/page-header/tabs.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-pageHeader__tabs"
+  ...attributes
+  data-test-page-header-tabs
+>
+  {{yield}}
+</div>

--- a/packages/pds-ember/addon/components/pds/page-header/title.hbs
+++ b/packages/pds-ember/addon/components/pds/page-header/title.hbs
@@ -1,0 +1,10 @@
+<h1
+  class="
+    pds-pageHeader__title
+    pds-heading pds--1
+  "
+  ...attributes
+  data-test-page-header-title
+>
+  {{yield}}
+</h1>

--- a/packages/pds-ember/addon/components/pds/page/body.hbs
+++ b/packages/pds-ember/addon/components/pds/page/body.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-page__body"
+  ...attributes
+  data-test-page-body
+>
+  {{ yield }}
+</div>

--- a/packages/pds-ember/addon/components/pds/page/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/page/docs.mdx
@@ -1,0 +1,44 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / Page';
+
+# Page
+Provides components for consistent Page layout.
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+
+```handlebars
+<Pds::Page as |P|>
+  <P.Header>...</P.Header>
+  <P.Body>...</P.Body>
+</Pds::Page>
+```
+* `<P.Header>` is an alias for `<Pds::PageHeader>`
+* `<P.Body>` is a wrapper for body content.
+
+<ArgsTable of="PdsPage" />
+
+
+## Styling
+```scss
+@use "pds/components/page";
+```
+
+
+## Markup
+The `<Pds::Page>` and its subcomponents handle generation of semantic markup.
+
+
+## Accessibility
+TBD...
+
+
+## See Also
+- [PageHeader](?path=/docs/components-pageheader--index)
+

--- a/packages/pds-ember/addon/components/pds/page/index.hbs
+++ b/packages/pds-ember/addon/components/pds/page/index.hbs
@@ -1,0 +1,10 @@
+<div
+  class="pds-page"
+  ...attributes
+  data-test-page
+>
+  {{ yield (hash
+    Header=(component 'pds/page-header')
+    Body=(component 'pds/page/body')
+  )}}
+</div>

--- a/packages/pds-ember/addon/components/pds/page/index.js
+++ b/packages/pds-ember/addon/components/pds/page/index.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component'
+
+/**
+ * @class PdsPage
+ */
+export default class PdsPage extends Component {}

--- a/packages/pds-ember/addon/components/pds/page/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/page/stories/index.stories.js
@@ -1,0 +1,85 @@
+import hbs from 'htmlbars-inline-precompile'
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: TITLE,
+  component: 'PdsPage',
+  subcomponents: {
+    'P.Header': 'PdsPageHeader',
+    'P.Body': 'PdsPageBody',
+  },
+  parameters: { docs: { page: DocsPage } },
+  argTypes: {
+    headerVariant: {
+      name: 'header variant',
+      defaultValue: '',
+      control: {
+        type: 'radio',
+        options: {
+          'plain (default)': '',
+          'filled': 'filled',
+        },
+      },
+    },
+    headerActionVariant: {
+      name: 'header action variant',
+      control: {
+        type: 'radio',
+        options: ['primary', 'warning'],
+      }
+    },
+  },
+  args: {
+    showActions: true,
+    showTabs: true,
+    headerVariant: 'filled',
+    headerActionVariant: 'primary',
+    pageTitle: 'Page Title',
+  },
+}
+
+export const Index = (args) => ({
+  template: hbs`
+    <Pds::Page as |P|>
+      <P.Header @variant={{headerVariant}} as |H|>
+        <H.Breadcrumbs>
+          <Docs::Breadcrumbs
+            @depth={{3}}
+            @showIcon={{true}}
+          />
+        </H.Breadcrumbs>
+
+        <H.Title>
+          {{pageTitle}}
+        </H.Title>
+
+        {{#if showActions}}
+          <H.Actions>
+            <Pds::ButtonSet>
+              <Pds::Button @variant={{headerActionVariant}}>
+                {{headerActionVariant}}
+              </Pds::Button>
+              <Pds::Dropdown @align="right" as |D|>
+                <D.Trigger>secondary</D.Trigger>
+                <D.Dialog>
+                  <Docs::ContentSkeleton />
+                </D.Dialog>
+              </Pds::Dropdown>
+            </Pds::ButtonSet>
+          </H.Actions>
+        {{/if}}
+
+        {{#if showTabs}}
+          <H.Tabs>
+            <Docs::TabNav />
+          </H.Tabs>
+        {{/if}}
+      </P.Header>
+
+      <P.Body>
+        Body Content
+      </P.Body>
+    </Pds::Page>
+  `,
+  context: args,
+})

--- a/packages/pds-ember/addon/components/pds/tab-nav/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/tab-nav/stories/index.stories.js
@@ -9,13 +9,7 @@ export default {
 
 export const Index = (args) => ({
   template: hbs`
-    <Pds::TabNav>
-      <a href="#" class="active">Tab 1</a>
-      <a href="#">Tab 2</a>
-      <a href="#">Tab 3</a>
-      <a href="#">Tab 4</a>
-      <a href="#" class="disabled">Tab 5</a>
-    </Pds::TabNav>
+    <Docs::TabNav />
   `,
   context: args,
 })

--- a/packages/pds-ember/app/components/pds/button-set.js
+++ b/packages/pds-ember/app/components/pds/button-set.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/button-set';

--- a/packages/pds-ember/app/components/pds/page-header/actions.js
+++ b/packages/pds-ember/app/components/pds/page-header/actions.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page-header/actions';

--- a/packages/pds-ember/app/components/pds/page-header/breadcrumbs.js
+++ b/packages/pds-ember/app/components/pds/page-header/breadcrumbs.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page-header/breadcrumbs';

--- a/packages/pds-ember/app/components/pds/page-header/index.js
+++ b/packages/pds-ember/app/components/pds/page-header/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page-header';

--- a/packages/pds-ember/app/components/pds/page-header/tabs.js
+++ b/packages/pds-ember/app/components/pds/page-header/tabs.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page-header/tabs';

--- a/packages/pds-ember/app/components/pds/page-header/title.js
+++ b/packages/pds-ember/app/components/pds/page-header/title.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page-header/title';

--- a/packages/pds-ember/app/components/pds/page/body.js
+++ b/packages/pds-ember/app/components/pds/page/body.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page/body';

--- a/packages/pds-ember/app/components/pds/page/index.js
+++ b/packages/pds-ember/app/components/pds/page/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/page';

--- a/packages/pds-ember/app/styles/pds/components/button-set/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/button-set/__config.scss
@@ -1,0 +1,24 @@
+///-------------------------------------------------------------------------///
+/// WARNING: Private Sass module (definitions may change at ANY time)
+///-------------------------------------------------------------------------///
+$_module: "PDS.Components.ButtonSet";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../../theme";
+
+$columnGap: theme.$size--sm;
+
+@mixin layout {
+  /* [debug] #{$_module}@layout */
+  display: flex; // non-wrapping
+
+  > * + * {
+    margin-inline-start: $columnGap;
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  .pds-buttonSet {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/button-set/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/button-set/index.scss
@@ -1,0 +1,5 @@
+@use "__config" as *;
+
+@include apply {
+  @include layout;
+}

--- a/packages/pds-ember/app/styles/pds/components/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/index.scss
@@ -22,6 +22,7 @@
 @use "logomark";
 @use "modal";
 @use "nav";
+@use "page";
 @use "page-header";
 @use "radio-field";
 @use "select";

--- a/packages/pds-ember/app/styles/pds/components/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/index.scss
@@ -22,6 +22,7 @@
 @use "logomark";
 @use "modal";
 @use "nav";
+@use "page-header";
 @use "radio-field";
 @use "select";
 @use "sidebar";

--- a/packages/pds-ember/app/styles/pds/components/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/index.scss
@@ -2,6 +2,7 @@
 @use "banner";
 @use "breadcrumbs";
 @use "button";
+@use "button-set";
 @use "checkbox-field";
 @use "code-block";
 @use "cta-link";

--- a/packages/pds-ember/app/styles/pds/components/page-header/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/page-header/__config.scss
@@ -1,0 +1,81 @@
+///-------------------------------------------------------------------------///
+/// WARNING: Private Sass module (definitions may change at ANY time)
+///-------------------------------------------------------------------------///
+$_module: "PDS.Components.PageHeader";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../../theme";
+@use "../../tokens/color";
+@use "../../tokens/scale";
+@use "../_config" as Component;
+@use "../tab-nav/_config" as TabNav;
+
+@mixin theme($styles) {
+  /* [debug] #{$_module}@theme */
+  @include Component.theme(pageHeader, $styles);
+}
+
+//  1fr           auto
+// +-------------+-------------+
+// | breadcrumbs | breadcrumbs | auto
+// +-------------+-------------+
+// | title       | actions     | auto
+// +-------------+-------------+
+// | tabs        | tabs        | auto
+// +-------------+-------------+
+@mixin layout {
+  /* [debug] #{$_module}@layout */
+  display: grid;
+  flex-shrink: 0;
+  grid-gap: 1rem;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'breadcrumbs breadcrumbs'
+    'title       actions'
+    'tabs        tabs';
+  padding: scale.$lg--3 theme.$size--2xl theme.$size--lg; // 28 48 24 48
+
+  &__actions {
+    grid-area: actions;
+    justify-self: end;
+  }
+
+  &__breadcrumbs {
+    grid-area: breadcrumbs;
+  }
+
+  &__tabs {
+    grid-area: tabs;
+    /// container eats bottom white space via negative margin, so that
+    /// it butts up against the bottom edge of the container
+    margin-block-end: -(theme.$size--lg);
+  }
+
+  &__title {
+    grid-area: title;
+  }
+}
+
+@mixin appearance {
+  /* [debug] #{$_module}@appearance */
+  background-color: transparent;
+  border: none;
+
+  // Filled
+  &.pds--filled {
+    background-color: color.$ui-gray-010;
+    border-bottom: 1px solid theme.$borderColor;
+  }
+
+  &.pds--filled &__tabs {
+    @include TabNav.apply {
+      border: none;
+    }
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  .pds-pageHeader {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/page-header/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/page-header/index.scss
@@ -1,0 +1,6 @@
+@use "__config" as *;
+
+@include apply {
+  @include layout;
+  @include appearance;
+}

--- a/packages/pds-ember/app/styles/pds/components/page/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/page/__config.scss
@@ -1,0 +1,32 @@
+///-------------------------------------------------------------------------///
+/// WARNING: Private Sass module (definitions may change at ANY time)
+///-------------------------------------------------------------------------///
+$_module: "PDS.Components.Page";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../../theme";
+@use "../page-header/_config" as PageHeader;
+
+@mixin layout {
+  /* [debug] #{$_module}@layout */
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+
+  &__body {
+    flex-grow: 1;
+    padding: 0 theme.$size--2xl theme.$size--2xl; // 0 48 48 48
+  }
+
+  @include PageHeader.apply {
+    &.pds--filled + .pds-page__body {
+      padding-block-start: theme.$size--xl; // 36
+    }
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  .pds-page {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/page/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/page/index.scss
@@ -1,0 +1,5 @@
+@use "__config" as *;
+
+@include apply {
+  @include layout;
+}

--- a/packages/pds-ember/tests/dummy/app/components/docs/button/button.hbs
+++ b/packages/pds-ember/tests/dummy/app/components/docs/button/button.hbs
@@ -1,6 +1,6 @@
 <section>
   <h2>&lt;Pds::Button&gt;</h2>
-  <div class="button-set">
+  <Pds::ButtonSet>
     {{!-- PRIMARY --}}
     <Pds::Button
       @variant="primary"
@@ -35,5 +35,5 @@
     >
       Ghost
     </Pds::Button>
-  </div>
+  </Pds::ButtonSet>
 </section>

--- a/packages/pds-ember/tests/dummy/app/components/docs/button/input.hbs
+++ b/packages/pds-ember/tests/dummy/app/components/docs/button/input.hbs
@@ -1,6 +1,6 @@
 <section>
   <h2>&lt;Pds::Input&gt;</h2>
-  <div class="button-set">
+  <Pds::ButtonSet>
     {{!-- PRIMARY --}}
     <Pds::Input
       @type="button"
@@ -35,5 +35,5 @@
       ...attributes
       data-test-visreg="input-button-ghost"
     />
-  </div>
+  </Pds::ButtonSet>
 </section>

--- a/packages/pds-ember/tests/dummy/app/components/docs/tab-nav/index.hbs
+++ b/packages/pds-ember/tests/dummy/app/components/docs/tab-nav/index.hbs
@@ -1,0 +1,7 @@
+<Pds::TabNav>
+  <a href="#" class="active">Tab 1</a>
+  <a href="#">Tab 2</a>
+  <a href="#">Tab 3</a>
+  <a href="#">Tab 4</a>
+  <a href="#" class="disabled">Tab 5</a>
+</Pds::TabNav>

--- a/packages/pds-ember/tests/dummy/app/styles/_shame.scss
+++ b/packages/pds-ember/tests/dummy/app/styles/_shame.scss
@@ -1,12 +1,5 @@
 @use "pds/theme";
 
-// TODO: replace with <Pds::Page> styles
-.pds-page {
-  > * {
-    margin-block-end: theme.$size--2xl;
-  }
-}
-
 // TODO: replace with proper PDS table styles
 .pds-table {
   td, th {

--- a/packages/pds-ember/tests/dummy/app/styles/app.scss
+++ b/packages/pds-ember/tests/dummy/app/styles/app.scss
@@ -51,18 +51,14 @@
   @import "blueprint";
   @import "figure";
 
-  // SHAME (TODO: migrate the below styles to the appropriate location)
-
-  .button-set {
-    display: flex;
-    flex-wrap: wrap;
-
-    > * { margin: 0.75rem 0; }
-    > * + * { margin-inline-start: 0.75rem; }
-  }
-
   .docs-formField-select {
     max-width: 20rem;
+  }
+
+  .docs-button {
+    > * + * {
+      margin: 0.75rem 0;
+    }
   }
 }
 

--- a/packages/pds-ember/tests/integration/components/button-set-test.js
+++ b/packages/pds-ember/tests/integration/components/button-set-test.js
@@ -1,0 +1,37 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+const ROOT = '[data-test-button-set]'
+
+module('Integration | Components.ButtonSet', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <Pds::ButtonSet
+        data-foo="bar"
+      />
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasNoText()
+      .hasAttribute('data-foo', 'bar', 'applies ...attributes')
+      .hasClass('pds-buttonSet')
+
+    // Template block usage:
+    await render(hbs`
+      <Pds::ButtonSet>
+        template block text
+      </Pds::ButtonSet>
+    `)
+
+    assert
+      .dom(ROOT)
+      .hasText('template block text')
+  })
+})
+

--- a/packages/pds-ember/tests/integration/components/page-header-test.js
+++ b/packages/pds-ember/tests/integration/components/page-header-test.js
@@ -1,0 +1,78 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+const ROOT = '[data-test-page-header]'
+const ACTIONS = '[data-test-page-header-actions]'
+const BREADCRUMBS = '[data-test-page-header-breadcrumbs]'
+const TITLE = '[data-test-page-header-title]'
+const TABS = '[data-test-page-header-tabs]'
+
+module('Integration | Components.PageHeader', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <Pds::PageHeader
+        data-foo="bar"
+        @variant={{this.variant}}
+        as |H|
+      >
+        <H.Actions data-name="actions">
+          actions
+        </H.Actions>
+
+        <H.Breadcrumbs data-name="breadcrumbs">
+          breadcrumbs
+        </H.Breadcrumbs>
+
+        <H.Title data-name="title">
+          title
+        </H.Title>
+
+        <H.Tabs data-name="tabs">
+          tabs
+        </H.Tabs>
+      </Pds::PageHeader>
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasText('actions breadcrumbs title tabs')
+      .hasAttribute('data-foo', 'bar', 'applies ...attributes')
+      .hasClass('pds-pageHeader')
+      .doesNotHaveClass('pds--filled', 'does not have filled variant class')
+
+    assert
+      .dom(ACTIONS)
+      .exists()
+      .hasText('actions')
+      .hasAttribute('data-name', 'actions', 'applies Actions ...attributes')
+
+    assert
+      .dom(BREADCRUMBS)
+      .exists()
+      .hasText('breadcrumbs')
+      .hasAttribute('data-name', 'breadcrumbs', 'applies Breadcrumbs ...attributes')
+
+    assert
+      .dom(TABS)
+      .exists()
+      .hasText('tabs')
+      .hasAttribute('data-name', 'tabs', 'applies Tabs ...attributes')
+
+    assert
+      .dom(TITLE)
+      .exists()
+      .hasText('title')
+      .hasAttribute('data-name', 'title', 'applies Title ...attributes')
+
+    this.set('variant', 'filled')
+    assert
+      .dom(ROOT)
+      .hasClass('pds--filled', 'has filled variant class')
+  })
+})
+

--- a/packages/pds-ember/tests/integration/components/page-test.js
+++ b/packages/pds-ember/tests/integration/components/page-test.js
@@ -1,0 +1,50 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+const ROOT = '[data-test-page]'
+const HEADER = '[data-test-page-header]'
+const BODY = '[data-test-page-body]'
+
+module('Integration | Components.Page', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <Pds::Page
+        data-foo="bar"
+        as |P|
+      >
+        <P.Header data-name="header">
+          header
+        </P.Header>
+
+        <P.Body data-name="body">
+          body
+        </P.Body>
+      </Pds::Page>
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasText('header body')
+      .hasAttribute('data-foo', 'bar', 'applies ...attributes')
+      .hasClass('pds-page')
+
+    assert
+      .dom(HEADER)
+      .exists()
+      .hasText('header')
+      .hasAttribute('data-name', 'header', 'applies Header ...attributes')
+      .hasClass('pds-pageHeader') // alias for <Pds::PageHeader>
+
+    assert
+      .dom(BODY)
+      .exists()
+      .hasText('body')
+      .hasAttribute('data-name', 'body', 'applies Body ...attributes')
+  })
+})
+


### PR DESCRIPTION
- Add `<Pds::ButtonSet>`
- Add `<Pds::PageHeader>`
- Add `<Pds::Page>` (with contextual subcomponents)
    - yields `<P.Header>` as an alias of `<Pds::PageHeader>`
- Update Docs