### PR TITLE
feat(pds-ember): add Copyright and GlobalFooter

### DIFF
--- a/packages/pds-ember/addon/components/pds/app/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/app/docs.mdx
@@ -68,4 +68,8 @@ This includes:
 
 
 ## See Also
-TBD...
+- [Banner](?path=/docs/components-banner--index)
+- [GlobalFooter](?path=/docs/components-globalfooter--index)
+- [Nav](?path=/docs/components-nav--index)
+- [PageHeader](?path=/docs/components-pageheader--index)
+- [Page](?path=/docs/components-page--index)

--- a/packages/pds-ember/addon/components/pds/app/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/app/stories/index.stories.js
@@ -72,7 +72,7 @@ export const Index = (args) => ({
       </App.Body>
 
       <App.Footer>
-        App Footer
+        <Pds::GlobalFooter />
       </App.Footer>
 
       <App.Drawer>

--- a/packages/pds-ember/addon/components/pds/copyright/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/copyright/docs.mdx
@@ -1,0 +1,40 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / Copyright';
+
+# Copyright
+Provides semi-static content (automatically updates year) to display the
+HashiCorp logomark along with copyright text.
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+
+```handlebars
+<Pds::Copyright />
+```
+<ArgsTable of="PdsCopyright" />
+
+
+## Styling
+```scss
+@use "pds/components/copyright";
+```
+
+* Component should be styled as if it were text.
+    * Avoid explicitly resizing the logomark
+
+## Markup
+The `<Pds::Copyright>` Ember component handles generation of semantic markup.
+
+
+## Accessibility
+TBD...
+
+
+## See Also
+- [GlobalFooter](?path=/docs/components-globalfooter--index)

--- a/packages/pds-ember/addon/components/pds/copyright/index.hbs
+++ b/packages/pds-ember/addon/components/pds/copyright/index.hbs
@@ -1,0 +1,13 @@
+<div
+  class="pds-copyright"
+  ...attributes
+  data-test-copyright
+>
+  <Pds::Logomark::Hashicorp
+    data-test-copyright-logomark
+  />
+
+  <span data-test-copyright-text>
+    &copy;{{this.year}} HashiCorp
+  </span>
+</div>

--- a/packages/pds-ember/addon/components/pds/copyright/index.js
+++ b/packages/pds-ember/addon/components/pds/copyright/index.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component'
+
+/**
+ * @class PdsCopyright
+ */
+export default class PdsCopyright extends Component {
+  get year() {
+    let d = new Date()
+    let year = d.getFullYear()
+    return year
+  }
+}

--- a/packages/pds-ember/addon/components/pds/copyright/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/copyright/stories/index.stories.js
@@ -1,0 +1,15 @@
+import hbs from 'htmlbars-inline-precompile'
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: TITLE,
+  component: 'PdsCopyright',
+  parameters: { docs: { page: DocsPage } },
+}
+
+export const Index = (args) => ({
+  template: hbs`
+    <Pds::Copyright />
+  `,
+  context: args,
+})

--- a/packages/pds-ember/addon/components/pds/global-footer/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/global-footer/docs.mdx
@@ -1,0 +1,43 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / GlobalFooter';
+
+# GlobalFooter
+Provides a styled container for presenting global footer content alongside
+standardized copyright info.
+
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+
+```handlebars
+<Pds::GlobalFooter as |F|>
+  <F.ProductName>...</F.ProductName>
+  <F.Nav>...</F.Nav>
+</Pds::GlobalFooter>
+```
+<ArgsTable of="PdsGlobalFooter" />
+
+
+## Styling
+```scss
+@use "pds/components/global-footer";
+```
+
+
+## Markup
+The `<Pds::GlobalFooter>` Ember component and its subcomponents handle
+generation of semantic markup and copyright info.
+
+
+## Accessibility
+TBD...
+
+
+## See Also
+- [Copyright](?path=/docs/components-copyright--index)

--- a/packages/pds-ember/addon/components/pds/global-footer/index.hbs
+++ b/packages/pds-ember/addon/components/pds/global-footer/index.hbs
@@ -1,0 +1,14 @@
+<div
+  class="pds-globalFooter"
+  ...attributes
+  data-test-global-footer
+>
+  <Pds::Copyright
+    data-test-global-footer-copyright
+  />
+
+  {{yield (hash
+    ProductName=(component 'pds/global-footer/product-name')
+    Nav=(component 'pds/global-footer/nav')
+  )}}
+</div>

--- a/packages/pds-ember/addon/components/pds/global-footer/index.js
+++ b/packages/pds-ember/addon/components/pds/global-footer/index.js
@@ -1,0 +1,6 @@
+import Component from '@glimmer/component'
+
+/**
+ * @class PdsGlobalFooter
+ */
+export default class PdsGlobalFooter extends Component {}

--- a/packages/pds-ember/addon/components/pds/global-footer/nav.hbs
+++ b/packages/pds-ember/addon/components/pds/global-footer/nav.hbs
@@ -1,0 +1,7 @@
+<nav
+  class="pds-globalFooter__nav"
+  ...attributes
+  data-test-global-footer-nav
+>
+  {{yield}}
+</nav>

--- a/packages/pds-ember/addon/components/pds/global-footer/product-name.hbs
+++ b/packages/pds-ember/addon/components/pds/global-footer/product-name.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-globalFooter__productName"
+  ...attributes
+  data-test-global-footer-product-name
+>
+  {{yield}}
+</div>

--- a/packages/pds-ember/addon/components/pds/global-footer/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/global-footer/stories/index.stories.js
@@ -1,0 +1,53 @@
+import hbs from 'htmlbars-inline-precompile'
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: TITLE,
+  component: 'PdsGlobalFooter',
+  parameters: { docs: { page: DocsPage } },
+}
+
+export const Index = (args) => ({
+  template: hbs`
+    <Pds::GlobalFooter />
+  `,
+  context: args,
+})
+
+export const WithProductName = (args) => ({
+  template: hbs`
+    <Pds::GlobalFooter as |F|>
+      <F.ProductName>
+        Product Name v1.2.3-rc.4
+      </F.ProductName>
+    </Pds::GlobalFooter>
+  `,
+  context: args,
+})
+
+export const WithNav = (args) => ({
+  template: hbs`
+    <Pds::GlobalFooter as |F|>
+      <F.Nav>
+        <a href="#">Documentation</a>
+        <a href="#">Notices</a>
+      </F.Nav>
+    </Pds::GlobalFooter>
+  `,
+  context: args,
+})
+
+export const WithProductNameAndNav = (args) => ({
+  template: hbs`
+    <Pds::GlobalFooter as |F|>
+      <F.ProductName>
+        Product Name v1.2.3-rc.4
+      </F.ProductName>
+      <F.Nav>
+        <a href="#">Documentation</a>
+        <a href="#">Notices</a>
+      </F.Nav>
+    </Pds::GlobalFooter>
+  `,
+  context: args,
+})

--- a/packages/pds-ember/app/components/pds/copyright.js
+++ b/packages/pds-ember/app/components/pds/copyright.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/copyright';

--- a/packages/pds-ember/app/components/pds/global-footer/index.js
+++ b/packages/pds-ember/app/components/pds/global-footer/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/global-footer';

--- a/packages/pds-ember/app/components/pds/global-footer/nav.js
+++ b/packages/pds-ember/app/components/pds/global-footer/nav.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/global-footer/nav';

--- a/packages/pds-ember/app/components/pds/global-footer/product-name.js
+++ b/packages/pds-ember/app/components/pds/global-footer/product-name.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/global-footer/product-name';

--- a/packages/pds-ember/app/styles/pds/components/copyright/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/copyright/__config.scss
@@ -1,0 +1,35 @@
+///-------------------------------------------------------------------------///
+/// WARNING: Private Sass module (definitions may change at ANY time)
+///-------------------------------------------------------------------------///
+$_module: "PDS.Components.Copyright";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../../theme";
+@use "../logomark/_config" as Logomark;
+
+@mixin layout {
+  /* [debug] #{$_module}@layout */
+  align-items: center;
+  display: inline-flex;
+  line-height: 1;
+
+  // child spacing
+  > * + * {
+    margin-inline-start: theme.$size--xs;
+  }
+}
+
+// NOTE: Most styling should be applied externally as if content
+//       were treated like body copy.
+@mixin appearance {
+  /* [debug] #{$_module}@appearance */
+  @include Logomark.apply {
+    font-size: 1.25em; // scales with text
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  .pds-copyright {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/copyright/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/copyright/index.scss
@@ -1,0 +1,6 @@
+@use "__config" as *;
+
+@include apply {
+  @include layout;
+  @include appearance;
+}

--- a/packages/pds-ember/app/styles/pds/components/global-footer/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/global-footer/__config.scss
@@ -1,0 +1,59 @@
+///-------------------------------------------------------------------------///
+/// WARNING: Private Sass module (definitions may change at ANY time)
+///-------------------------------------------------------------------------///
+$_module: "PDS.Components.GlobalFooter";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../../core/typography/_config" as Typography;
+@use "../../theme";
+@use "../../tokens/color";
+@use "../link/_config" as Link;
+@use "../link/incognito/_config" as IncognitoLink;
+
+$backgroundColor: color.$white;
+$borderColor: theme.$borderColor;
+$borderWidth: 1px;
+$color: color.$ui-gray-500;
+
+@mixin layout {
+  /* [debug] #{$_module}@layout */
+  display: flex;
+  justify-content: center; // center content horizontally
+  padding: theme.$size--lg;
+
+  > * {
+    // children spacing
+    + * {
+      margin-inline-start: theme.$size--lg;
+    }
+
+    // grandchildren spacing
+    > * + * {
+      margin-inline-start: theme.$size--xs;
+    }
+  }
+
+  &__productName,
+  &__nav {
+    align-items: center;
+    display: flex;
+  }
+}
+
+@mixin appearance {
+  /* [debug] #{$_module}@appearance */
+  @include Typography.Interface(S);
+  background-color: $backgroundColor;
+  border-top: $borderWidth solid $borderColor;
+  color: $color;
+
+  @include Link.apply {
+    @include IncognitoLink.appearance;
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  .pds-globalFooter {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/global-footer/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/global-footer/index.scss
@@ -1,0 +1,6 @@
+@use "__config" as *;
+
+@include apply {
+  @include layout;
+  @include appearance;
+}

--- a/packages/pds-ember/app/styles/pds/components/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/index.scss
@@ -5,6 +5,7 @@
 @use "button-set";
 @use "checkbox-field";
 @use "code-block";
+@use "copyright";
 @use "cta-link";
 @use "definition-list";
 @use "drawer";
@@ -14,6 +15,7 @@
 @use "external-link";
 @use "field-name";
 @use "form-field";
+@use "global-footer";
 @use "help-text";
 @use "icon";
 @use "input";

--- a/packages/pds-ember/app/styles/pds/components/link/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/__config.scss
@@ -9,6 +9,8 @@ $_module: "PDS.Components.Link";
   @include Component.theme(link, $styles);
 }
 
+$borderWidth: 1px;
+
 // Themable Properties with defaults
 $backgroundColor: var(--pds-link-backgroundColor, transparent);
 $borderColor: var(--pds-link-borderColor, transparent);
@@ -17,10 +19,16 @@ $color: var(--pds-link-color, inherit);
 $textDecoration: var(--pds-link-textDecoration, none);
 
 
+// [1] accounts for invisible border (which adds height)
+//     to correct vertical alignment with adjacent, non-link text
+@mixin layout {
+  margin-block-end: -($borderWidth); // [1]
+}
+
 @mixin appearance {
   /* [debug] #{$_module}@appearance */
   background-color: $backgroundColor;
-  border-bottom: 1px solid $borderColor;
+  border-bottom: $borderWidth solid $borderColor;
   box-shadow: $boxShadow;
   color: $color;
   cursor: pointer;

--- a/packages/pds-ember/app/styles/pds/components/link/_base.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/_base.scss
@@ -1,5 +1,6 @@
 @use "__config" as BaseLink;
 
 @include BaseLink.apply {
+  @include BaseLink.layout;
   @include BaseLink.appearance;
 }

--- a/packages/pds-ember/tests/integration/components/copyright/index-test.js
+++ b/packages/pds-ember/tests/integration/components/copyright/index-test.js
@@ -1,0 +1,40 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+const ROOT = '[data-test-copyright]'
+const LOGOMARK = '[data-test-copyright-logomark]'
+const TEXT = '[data-test-copyright-text]'
+
+module('Integration | Components.Copyright', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <Pds::Copyright data-foo="bar">
+        template block text
+      </Pds::Copyright>
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasAttribute('data-foo', 'bar', 'applies ...attributes')
+      .hasClass('pds-copyright')
+
+    assert
+      .dom(ROOT)
+      .doesNotIncludeText('template block text', 'ignores template block')
+
+    assert
+      .dom(LOGOMARK)
+      .exists()
+      .isVisible()
+
+    assert
+      .dom(TEXT)
+      .hasText(/\d{4} HashiCorp/, 'renders expected copyright text')
+  })
+})
+

--- a/packages/pds-ember/tests/integration/components/global-footer/index-test.js
+++ b/packages/pds-ember/tests/integration/components/global-footer/index-test.js
@@ -1,0 +1,76 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+const ROOT = '[data-test-global-footer]'
+const COPYRIGHT = '[data-test-global-footer-copyright]'
+const PRODUCT_NAME = '[data-test-global-footer-product-name]'
+const NAV = '[data-test-global-footer-nav]'
+
+module('Integration | Components.GlobalFooter', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it renders inline', async function(assert) {
+    await render(hbs`
+      <Pds::GlobalFooter />
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasClass('pds-globalFooter')
+
+    assert
+      .dom(COPYRIGHT)
+      .exists()
+
+    assert
+      .dom(PRODUCT_NAME)
+      .doesNotExist()
+
+    assert
+      .dom(NAV)
+      .doesNotExist()
+  })
+
+  test('it renders contextual subcomponents', async function(assert) {
+    await render(hbs`
+      <Pds::GlobalFooter
+        data-name="global-footer"
+        as |F|
+      >
+        <F.ProductName data-name="product-name">
+          product name
+        </F.ProductName>
+
+        <F.Nav data-name="nav">
+          nav
+        </F.Nav>
+      </Pds::GlobalFooter>
+    `)
+
+    assert
+      .dom(ROOT)
+      .hasAttribute('data-name', 'global-footer', 'applies root ...attributes')
+
+    assert
+      .dom(COPYRIGHT)
+      .exists()
+
+    assert
+      .dom(PRODUCT_NAME)
+      .exists()
+      .hasClass('pds-globalFooter__productName')
+      .hasAttribute('data-name', 'product-name', 'applies ProductName ...attributes')
+      .hasText('product name')
+
+    assert
+      .dom(NAV)
+      .exists()
+      .hasClass('pds-globalFooter__nav')
+      .hasAttribute('data-name', 'nav', 'applies Nav ...attributes')
+      .hasText('nav')
+  })
+})
+


### PR DESCRIPTION
JIRA: PDS-226

- Add `<Pds::Copyright>`
- Add `<Pds::GlobalFooter>`
- Update `<Pds::App>` story to demo usage of `<Pds::GlobalFooter>`
- Update App docs with cross links to relevant components

## Screenshots

### Copyright
![Copyright - Basic](https://user-images.githubusercontent.com/545605/100478810-fb655980-30b1-11eb-9258-2f875bdf38e1.png)

### GlobalFooter
__Basic__
![GlobalFooter - Basic](https://user-images.githubusercontent.com/545605/100478809-fb655980-30b1-11eb-8ae6-c8a819fe8630.png)

__Copyright + Product Name__
![GlobalFooter - Copyright + Product Name](https://user-images.githubusercontent.com/545605/100478808-fb655980-30b1-11eb-8ff3-935ce1725b00.png)

__Copyright + Nav__
![GlobalFooter - Copyright + Nav](https://user-images.githubusercontent.com/545605/100478807-faccc300-30b1-11eb-9457-e0754b970e0c.png)

__Copyright + Product Name + Nav__
![GlobalFooter - Copyright + Product Name + Nav](https://user-images.githubusercontent.com/545605/100478805-faccc300-30b1-11eb-87ff-74d1b7e917a0.png)
