### PR TITLE
feat(pds-ember): add ErrorState

### DIFF
--- a/packages/pds-ember/addon/components/pds/empty-state/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/empty-state/docs.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable } from '@storybook/addon-docs/blocks';
-export const TITLE = 'Components / Empty State';
+export const TITLE = 'Components / EmptyState';
 
-# Empty State
+# EmptyState
 The `<Pds::EmptyState>` provides a means to arrange simple content in UI views
 that communicate a lack of data to end users.
 
@@ -44,4 +44,4 @@ TBD...
 
 
 ## See Also
-TBD...
+- [ErrorState](?path=/docs/components-errorstate--index)

--- a/packages/pds-ember/addon/components/pds/error-state/body.hbs
+++ b/packages/pds-ember/addon/components/pds/error-state/body.hbs
@@ -1,0 +1,7 @@
+<div
+  class="pds-errorState__body"
+  ...attributes
+  data-test-error-state-body
+>
+  {{ yield }}
+</div>

--- a/packages/pds-ember/addon/components/pds/error-state/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/error-state/docs.mdx
@@ -1,0 +1,46 @@
+import { ArgsTable } from '@storybook/addon-docs/blocks';
+export const TITLE = 'Components / ErrorState';
+
+# ErrorState
+The `<Pds::ErrorState>` component provides a means to arrange simple content in
+UI views that communicate an error to end users (e.g., HTTP 403, HTTP 404,
+HTTP 500, etc.)
+
+- [Usage](#usage)
+- [Styling](#styling)
+- [Markup](#markup)
+- [Accessibility](#accessibility)
+- [See Also](#see-also)
+
+
+## Usage
+```handlebars
+<Pds::ErrorState as |E|>
+  <E.Body>...</E.Body>
+  <E.Footer>...</E.Footer>
+</Pds::ErrorState>
+```
+<ArgsTable of="PdsErrorState" />
+
+
+## Styling
+```scss
+@use "pds/components/error-state";
+```
+
+**NOTE:** The root component (`<Pds::ErrorState>`) does not include any
+internal padding.  It is designed to reside within the _content box_ of a parent
+element.
+
+
+## Markup
+The `<Pds::ErrorState>` Ember component and its subcomponents handle generation
+of semantic markup.
+
+
+## Accessibility
+TBD...
+
+
+## See Also
+- [EmptyState](?path=/docs/components-emptystate--index)

--- a/packages/pds-ember/addon/components/pds/error-state/footer.hbs
+++ b/packages/pds-ember/addon/components/pds/error-state/footer.hbs
@@ -1,0 +1,7 @@
+<footer
+  class="pds-errorState__footer"
+  ...attributes
+  data-test-error-state-footer
+>
+  {{ yield }}
+</footer>

--- a/packages/pds-ember/addon/components/pds/error-state/index.hbs
+++ b/packages/pds-ember/addon/components/pds/error-state/index.hbs
@@ -1,0 +1,42 @@
+<div
+  class="pds-errorState"
+  ...attributes
+  data-test-error-state
+>
+  <header
+    class="pds-errorState__header"
+    data-test-error-state-header
+  >
+    <div class="pds-errorState__icon">
+      <Pds::Icon
+        @type={{this.icon}}
+        data-test-error-state-icon
+      />
+    </div>
+
+    <div class="pds-errorState__headings">
+      {{#if @title}}
+        <h1
+          class="pds-errorState__title"
+          data-test-error-state-title
+        >
+          {{@title}}
+        </h1>
+      {{/if}}
+
+      {{#if @subtitle}}
+        <span
+          class="pds-errorState__subtitle"
+          data-test-error-state-subtitle
+        >
+          {{@subtitle}}
+        </span>
+      {{/if}}
+    </div>
+  </header>
+
+  {{ yield (hash
+    Body=(component 'pds/error-state/body')
+    Footer=(component 'pds/error-state/footer')
+  )}}
+</div>

--- a/packages/pds-ember/addon/components/pds/error-state/index.js
+++ b/packages/pds-ember/addon/components/pds/error-state/index.js
@@ -1,0 +1,34 @@
+import Component from '@glimmer/component'
+
+const DEFAULT_ICON = 'alert-circle-outline'
+
+/**
+ * @class PdsErrorState
+ */
+
+/**
+ * Title text for communicated error.
+ *
+ * @argument title
+ * @type {string}
+ */
+
+/**
+ * Subtitle text for communicated error.
+ *
+ * @argument subtitle
+ * @type {string}
+ */
+export default class PdsErrorState extends Component {
+  /**
+   * Icon to display next to title/subtitle.
+   *
+   * @argument icon
+   * @type {string}
+   * @default alert-circle-outline
+   */
+  get icon() {
+    let { icon } = this.args
+    return icon ? icon : DEFAULT_ICON
+  }
+}

--- a/packages/pds-ember/addon/components/pds/error-state/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/error-state/stories/index.stories.js
@@ -1,0 +1,131 @@
+import hbs from 'htmlbars-inline-precompile'
+import ICONS from '@hashicorp/structure-icons/dist/index';
+import DocsPage, { TITLE } from '../docs.mdx'
+
+export default {
+  title: TITLE,
+  component: 'PdsErrorState',
+  parameters: { docs: { page: DocsPage } },
+}
+
+export const Index = (args) => ({
+  template: hbs`
+    <Pds::ErrorState
+      @title={{title}}
+      @subtitle={{subtitle}}
+      @icon={{icon}}
+      as |E|
+    >
+      <E.Body>{{body}}</E.Body>
+      <E.Footer>
+        <a href="#">
+          <Pds::Icon @type="chevron-left" />
+          Go Back
+        </a>
+
+        <a href="#" class="pds--incognito">
+          Need Help?
+        </a>
+      </E.Footer>
+    </Pds::ErrorState>
+  `,
+  context: args,
+})
+Index.argTypes = {
+  icon: {
+    control: {
+      type: 'select',
+      options: ICONS,
+    }
+  },
+}
+Index.args = {
+  title: 'Error Title',
+  subtitle: 'Subtitle',
+  body: [
+    'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'Maecenas non orci odio.',
+    'Pellentesque condimentum malesuada orci, quis porttitor nibh auctor quis.'
+  ].join(' '),
+}
+
+export const HTTP403 = () => ({
+  template: hbs`
+    <Pds::ErrorState
+      @title="You are not authorized"
+      @subtitle="Error 403"
+      @icon="disabled"
+      as |E|
+    >
+      <E.Body>
+        You must be granted permissions to view this data.
+        Ask your administrator if you think you should have access.
+      </E.Body>
+
+      <E.Footer>
+        <a href="#">
+          <Pds::Icon @type="chevron-left" />
+          Go Back
+        </a>
+
+        <a href="#" class="pds--incognito">
+          Need Help?
+        </a>
+      </E.Footer>
+    </Pds::ErrorState>
+  `,
+})
+
+export const HTTP404 = () => ({
+  template: hbs`
+    <Pds::ErrorState
+      @title="Page not found"
+      @subtitle="Error 404"
+      @icon="help-circle-outline"
+      as |E|
+    >
+      <E.Body>
+        Sorry, we couldn't find the page you were looking for.
+        You can go back or to one of the links below.
+      </E.Body>
+
+      <E.Footer>
+        <a href="#">
+          <Pds::Icon @type="chevron-left" />
+          Go Back
+        </a>
+
+        <a href="#" class="pds--incognito">
+          Need Help?
+        </a>
+      </E.Footer>
+    </Pds::ErrorState>
+  `,
+})
+
+export const HTTP500 = () => ({
+  template: hbs`
+    <Pds::ErrorState
+      @title="Something went wrong"
+      @subtitle="Error 500"
+      @icon="alert-circle-outline"
+      as |E|
+    >
+      <E.Body>
+        We ran into a problem and could not continue. You can ask your
+        administrator or try again later.
+      </E.Body>
+
+      <E.Footer>
+        <a href="#">
+          <Pds::Icon @type="refresh-default" />
+          Try Again
+        </a>
+
+        <a href="#" class="pds--incognito">
+          Need Help?
+        </a>
+      </E.Footer>
+    </Pds::ErrorState>
+  `,
+})

--- a/packages/pds-ember/app/components/pds/error-state/body.js
+++ b/packages/pds-ember/app/components/pds/error-state/body.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/error-state/body';

--- a/packages/pds-ember/app/components/pds/error-state/footer.js
+++ b/packages/pds-ember/app/components/pds/error-state/footer.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/error-state/footer';

--- a/packages/pds-ember/app/components/pds/error-state/index.js
+++ b/packages/pds-ember/app/components/pds/error-state/index.js
@@ -1,0 +1,1 @@
+export { default } from '@hashicorp/pds-ember/components/pds/error-state';

--- a/packages/pds-ember/app/styles/pds/components/error-state/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/error-state/__config.scss
@@ -1,0 +1,82 @@
+///-------------------------------------------------------------------------///
+/// WARNING: Private Sass module (definitions may change at ANY time)
+///-------------------------------------------------------------------------///
+$_module: "PDS.Components.ErrorState";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../../core/typography/_config" as Typography;
+@use "../../theme";
+@use "../../tokens/color";
+
+$color: color.$ui-gray-500;
+
+@mixin layout {
+  /* [debug] #{$_module}@layout */
+  display: grid;
+  grid-gap: theme.$size-sm;
+  grid-template-areas:
+    'header'
+    'body'
+    'footer';
+  margin: 0 auto; // horizontally centered
+  max-width: 40ch;
+  padding: 0;
+
+  &__header {
+    display: grid;
+    grid-template-areas: 'icon headings';
+    grid-template-columns: auto 1fr;
+    grid-gap: 0 theme.$size--xs;
+  }
+
+  &__icon {
+    grid-area: icon;
+    line-height: 1;
+  }
+
+  &__headings {
+    display: flex;
+    flex-direction: column;
+    grid-area: headings;
+    justify-content: center;
+  }
+
+  &__footer {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-block-start: theme.$size--sm;
+    padding: theme.$size--xs 0;
+  }
+}
+
+@mixin appearance {
+  /* [debug] #{$_module}@appearance */
+  color: $color;
+
+  &__icon {
+    font-size: theme.$size--2xl;
+  }
+
+  &__title {
+    @include Typography.Heading(2);
+  }
+
+  &__subtitle {
+    @include Typography.Interface(S);
+  }
+
+  &__body {
+    @include Typography.Body;
+  }
+
+  &__footer {
+    border-top: 1px solid theme.$borderColor;
+  }
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  .pds-errorState {
+    @content;
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/error-state/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/error-state/index.scss
@@ -1,0 +1,6 @@
+@use "__config" as *;
+
+@include apply {
+  @include layout;
+  @include appearance;
+}

--- a/packages/pds-ember/app/styles/pds/components/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/index.scss
@@ -11,6 +11,7 @@
 @use "dropdown";
 @use "empty-state";
 @use "error-message";
+@use "error-state";
 @use "external-link";
 @use "field-name";
 @use "form-field";

--- a/packages/pds-ember/tests/integration/components/error-state/index-test.js
+++ b/packages/pds-ember/tests/integration/components/error-state/index-test.js
@@ -1,0 +1,124 @@
+import { module, test } from 'qunit'
+import { setupRenderingTest } from 'ember-qunit'
+import { render } from '@ember/test-helpers'
+import { hbs } from 'ember-cli-htmlbars'
+
+const ROOT = '[data-test-error-state]'
+const BODY = '[data-test-error-state-body]'
+const FOOTER = '[data-test-error-state-footer]'
+const ICON = '[data-test-error-state-icon]'
+const TITLE = '[data-test-error-state-title]'
+const SUBTITLE = '[data-test-error-state-subtitle]'
+
+module('Integration | Components.ErrorState', function(hooks) {
+  setupRenderingTest(hooks)
+
+  test('it renders', async function(assert) {
+    await render(hbs`
+      <Pds::ErrorState>
+        template block text
+      </Pds::ErrorState>
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasClass('pds-errorState')
+
+    assert
+      .dom(ICON)
+      .exists()
+
+    assert
+      .dom(TITLE)
+      .doesNotExist()
+
+    assert
+      .dom(SUBTITLE)
+      .doesNotExist()
+
+    assert
+      .dom(BODY)
+      .doesNotExist()
+
+    assert
+      .dom(FOOTER)
+      .doesNotExist()
+  })
+
+  test('it renders contextual components', async function(assert) {
+    await render(hbs`
+      <Pds::ErrorState data-name="error-state" as |E|>
+        <E.Body data-name="body">
+          body
+        </E.Body>
+
+        <E.Footer data-name="footer">
+          footer
+        </E.Footer>
+      </Pds::ErrorState>
+    `)
+
+    assert
+      .dom(ROOT)
+      .exists()
+      .hasAttribute('data-name', 'error-state', 'applies root ..attributes')
+      .hasClass('pds-errorState')
+
+    assert
+      .dom(BODY)
+      .exists()
+      .hasText('body')
+      .hasAttribute('data-name', 'body', 'applies body ...attributes')
+      .hasClass('pds-errorState__body')
+
+    assert
+      .dom(FOOTER)
+      .exists()
+      .hasText('footer')
+      .hasAttribute('data-name', 'footer', 'applies footer ...attributes')
+      .hasClass('pds-errorState__footer')
+  })
+
+  test('it supports @title', async function(assert) {
+    await render(hbs`
+      <Pds::ErrorState
+        @title="Custom Title"
+      />
+    `)
+
+    assert
+      .dom(TITLE)
+      .hasText('Custom Title')
+  })
+
+  test('it supports @subtitle', async function(assert) {
+    await render(hbs`
+      <Pds::ErrorState
+        @subtitle="Custom Subtitle"
+      />
+    `)
+
+    assert
+      .dom(SUBTITLE)
+      .hasText('Custom Subtitle')
+  })
+
+  test('it supports @icon', async function(assert) {
+    await render(hbs`
+      <Pds::ErrorState
+        @icon={{this.icon}}
+      />
+    `)
+
+    assert
+      .dom(ICON)
+      .hasAttribute('data-test-icon-type', 'alert-circle-outline', 'applies default icon')
+
+    this.set('icon', 'disabled')
+    assert
+      .dom(ICON)
+      .hasAttribute('data-test-icon-type', 'disabled', 'applies custom icon')
+  })
+})
+


### PR DESCRIPTION
(depends on #57)

- Add `<Pds::ErrorState>` component
- Add docs/examples for HTTP 403, 404, and 500 errors using the `<Pds::ErrorState>` component.

JIRA:
  * PDS-225
  * PDS-230

## Screenshots

_generic example_
![ErrorState - Example](https://user-images.githubusercontent.com/545605/100526776-b87ab300-3191-11eb-8504-9daddc0be596.png)

_HTTP 403 example_
![ErrorState - HTTP 403](https://user-images.githubusercontent.com/545605/100526775-b87ab300-3191-11eb-8a18-272aa2dfbf5a.png)

_HTTP 404 example_
![ErrorState - HTTP 404](https://user-images.githubusercontent.com/545605/100526774-b7e21c80-3191-11eb-8547-d85ec523b4cc.png)

_HTTP 500 example_
![ErrorState - HTTP 500](https://user-images.githubusercontent.com/545605/100526772-b7498600-3191-11eb-9714-fb9783d16c36.png)


