### PR TITLE
feat(pds-ember): add open modifier class to Dropdown::Dialog

### DIFF
--- a/packages/pds-ember/addon/components/pds/dropdown/dialog/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/dialog/index.hbs
@@ -1,5 +1,5 @@
 <div
-  class="pds-dropdownDialog"
+  class="pds-dropdownDialog {{if @isOpen 'pds--open'}}"
   ...attributes
   data-test-dropdown-dialog
 >

--- a/packages/pds-ember/addon/components/pds/dropdown/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/index.hbs
@@ -11,7 +11,7 @@
     isOpen=this.isOpen
     close=this.close
     Trigger=(component 'pds/dropdown/trigger' isOpen=this.isOpen)
-    Dialog=(component 'pds/dropdown/dialog')
+    Dialog=(component 'pds/dropdown/dialog' isOpen=this.isOpen)
     ListItem=(component 'pds/dropdown/list-item')
   )}}
 </details>

--- a/packages/pds-ember/tests/integration/components/dropdown/index-test.js
+++ b/packages/pds-ember/tests/integration/components/dropdown/index-test.js
@@ -47,6 +47,7 @@ module('Integration | Components.Dropdown', function(hooks) {
       .exists()
       .isNotVisible()
       .hasText('dialog content goes here')
+      .doesNotHaveClass('pds--open')
       .hasAttribute('data-name', 'dialog', 'applies ...attributes to dialog')
   })
 
@@ -73,6 +74,7 @@ module('Integration | Components.Dropdown', function(hooks) {
 
     assert
       .dom(DIALOG)
+      .hasClass('pds--open', 'applies open modifier class to Dialog')
       .isVisible()
   })
 


### PR DESCRIPTION
This PR adds a class name to the dialog in the `Pds::Dropdown` component. This allows us to add CSS transitions on hide / show of the dialog. 