### PR TITLE
Fix visually hidden elements still appearing as a 1px item in Firefox

### DIFF
--- a/packages/pds-ember/app/styles/pds/utils/_a11y.scss
+++ b/packages/pds-ember/app/styles/pds/utils/_a11y.scss
@@ -13,6 +13,11 @@ $_module: "PDS.Utils.A11y";
   // content from the a11y tree
   width: 1px !important;
   height: 1px !important;
+  clip: rect(1px, 1px, 1px, 1px); /* old & current Browsers */
+  clip-path: inset(50%); /* browsers in the future */
+
+  // Prevent the screen reader to skip spaces between words
+  white-space: nowrap;
 
   // eliminate any space being taken up by the element
   margin: -1px !important;


### PR DESCRIPTION
While working on https://github.com/hashicorp/waypoint/pull/1057, Rae found a bug in Firefox with the hidden radio field input being visible (in addition to the facade). This was even more obvious in dark mode because of the element's contrast. 

This is using `clip` on the `visuallyHidden` mixin, which seems to be a very common way to keep the element accessible (and it's even used in bootstrap: https://github.com/twbs/bootstrap/blob/main/scss/mixins/_visually-hidden.scss#L15), but I would welcome feedback on that.  

before: 
<img width="1947" alt="Screen Shot 2021-03-25 at 19 17 26" src="https://user-images.githubusercontent.com/1416421/112641705-e8397f00-8e42-11eb-83fc-81ce95b672fe.png">

after: 
<img width="1947" alt="Screen Shot 2021-03-26 at 14 53 13" src="https://user-images.githubusercontent.com/1416421/112641815-02735d00-8e43-11eb-9d01-7aab86adbe65.png">
