### PR TITLE
[HCPV-1090] Help Text Bold Variant

### DIFF
--- a/packages/pds-ember/addon/components/pds/help-text/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/help-text/docs.mdx
@@ -13,7 +13,9 @@ A visual style for blocks of text that provide additional context to the user.
 
 ## Usage
 ```hbs
-<Pds::HelpText>
+<Pds::HelpText
+ @variant={{string ['']}}
+>
   <!-- text content -->
 </Pds::HelpText>
 ```
@@ -29,6 +31,11 @@ A visual style for blocks of text that provide additional context to the user.
 ## Markup
 The `<Pds::HelpText>` Ember component handles generation of semantic HTML markup.
 
+### Modifier Classes
+For bold help text.
+
+* @variant
+  * **bold**: `pds-helpText--bold`
 
 ## Accessibility
 _TBD..._

--- a/packages/pds-ember/addon/components/pds/help-text/index.hbs
+++ b/packages/pds-ember/addon/components/pds/help-text/index.hbs
@@ -1,6 +1,5 @@
 <p
-  class="pds-helpText
-  {{this.variantClass}}"
+  class="pds-helpText {{this.variantClass}}"
   ...attributes
   data-test-root
 >

--- a/packages/pds-ember/addon/components/pds/help-text/index.hbs
+++ b/packages/pds-ember/addon/components/pds/help-text/index.hbs
@@ -1,5 +1,6 @@
 <p
-  class="pds-helpText"
+  class="pds-helpText
+  {{this.variantClass}}"
   ...attributes
   data-test-root
 >

--- a/packages/pds-ember/addon/components/pds/help-text/index.js
+++ b/packages/pds-ember/addon/components/pds/help-text/index.js
@@ -1,0 +1,28 @@
+import Component from '@glimmer/component';
+import { getVariantClass } from './utils';
+
+/**
+ * @class HelpText
+ */
+
+/**
+ * Display variant.
+ *
+ * _(default: `''`)_
+ *
+ * If left blank or not defined, defaults to "secondary" button appearance.
+ *
+ * Valid values include:
+ *
+ * - `bold`
+ *
+ * @argument variant
+ * @type { string }
+ * @default ''
+ */
+
+export default class extends Component {
+    get variantClass() {
+        return getVariantClass(this.args.variant);
+    }
+}

--- a/packages/pds-ember/addon/components/pds/help-text/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/help-text/stories/index.stories.js
@@ -19,7 +19,19 @@ const Index = () => ({
   `,
 });
 
+const Bold = () => ({
+  template: hbs`
+    <Pds::HelpText @variant='bold'>
+      Selecting the bottlenecks should allow our spike to rank the relative
+      branch off the emergence. Working the customers should allow our product
+      vision to estimate the quarterly feature past the complexity. It was
+      discovered that by always building the PR impediments, we can open the
+      visible XP branch upon the adaptive automation.
+    </Pds::HelpText>
+  `,
+});
 export {
   CONFIG as default,
   Index,
+  Bold
 }

--- a/packages/pds-ember/addon/components/pds/help-text/utils.js
+++ b/packages/pds-ember/addon/components/pds/help-text/utils.js
@@ -1,0 +1,17 @@
+export const VARIANT_CLASSES = {
+    bold: 'pds-helpText--bold',
+    regular: '',
+  };
+  
+export const DEFAULT_VARIANT = 'regular';
+
+export function getVariantClass(variant) {
+let result = '';
+
+if (VARIANT_CLASSES[variant]) {
+    result = VARIANT_CLASSES[variant];
+}
+
+return result;
+}
+  

--- a/packages/pds-ember/app/styles/pds/components/help-text/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/__config.scss
@@ -1,6 +1,7 @@
 $_module: "PDS.Components.HelpText";
 /* --- [debug] CONFIG: #{$_module} --- */
 @use "../../tokens/color";
+@use "../../tokens/font" as font;
 @use "../../core/typography/config" as Typography;
 
 $color: color.$ui-gray-500;
@@ -8,8 +9,8 @@ $color: color.$ui-gray-500;
 @mixin appearance {
   /* [debug] #{$_module}@appearance */
   @include Typography.Interface(S);
-
   color: $color;
+  font-weight: font.weight(Normal);
 }
 
 @mixin apply {

--- a/packages/pds-ember/app/styles/pds/components/help-text/_base.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/_base.scss
@@ -1,0 +1,5 @@
+@use "_config" as *;
+
+@include apply {
+  @include appearance;
+}

--- a/packages/pds-ember/app/styles/pds/components/help-text/bold/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/bold/__config.scss
@@ -1,13 +1,12 @@
 $_module: "PDS.Components.HelpText.Bold";
 /* --- [debug] CONFIG: #{$_module} --- */
-@use "../_config" as _super;
+@use "../__config" as _super;
+@use "../../../tokens/font" as font;
 
 @mixin appearance {
   /* [debug] #{$_module}@appearance */
 
-  font-weight: 500;
-  color: #f09;
-  background-color: #f09;
+  font-weight: font.weight(Medium);
 }
 
 @mixin apply {

--- a/packages/pds-ember/app/styles/pds/components/help-text/bold/_config.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/bold/_config.scss
@@ -1,0 +1,20 @@
+$_module: "PDS.Components.HelpText.Bold";
+/* --- [debug] CONFIG: #{$_module} --- */
+@use "../_config" as _super;
+
+@mixin appearance {
+  /* [debug] #{$_module}@appearance */
+
+  font-weight: 500;
+  color: #f09;
+  background-color: #f09;
+}
+
+@mixin apply {
+  /* [debug] #{$_module}@apply */
+  @include _super.apply {
+      &.pds-helpText--bold {
+      @content;
+    }
+  }
+}

--- a/packages/pds-ember/app/styles/pds/components/help-text/bold/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/bold/index.scss
@@ -1,4 +1,4 @@
-@use "_config" as *;
+@use "__config" as *;
 
 @include apply {
   @include appearance;

--- a/packages/pds-ember/app/styles/pds/components/help-text/bold/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/bold/index.scss
@@ -1,0 +1,5 @@
+@use "_config" as *;
+
+@include apply {
+  @include appearance;
+}

--- a/packages/pds-ember/app/styles/pds/components/help-text/index.scss
+++ b/packages/pds-ember/app/styles/pds/components/help-text/index.scss
@@ -1,5 +1,3 @@
-@use "config" as *;
-
-@include apply {
-  @include appearance;
-}
+@use "base";
+//Variants
+@use "bold";

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/pds-ember",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Ember addon for building Structure-styled UIs",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
The purpose of this PR is to add a bold variant to the `HelpText` component because a lot of help text on Vault Cloud uses a heavier weighted font.  It is also to set the default font weight on help text to 400 instead of 500.