### PR TITLE
Add warning with no border variant to banner

### DIFF
--- a/packages/pds-ember/addon/components/pds/banner/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/banner/docs.mdx
@@ -42,6 +42,17 @@ the consumer to conform to their individual use cases.
 The `<Pds::Banner>` and its subcomponents handle generation of semantic markup.
 
 
+## Variants
+Each variant maps to an icon.  Variant Name : Icon Name
+  * 'error': 'cancel-square-fill',
+  * 'info': 'info-circle-fill',
+  * 'info-no-border': 'info-circle-fill',
+  * 'success': 'check-circle-fill',
+  * 'warning': 'alert-triangle',
+  * 'warning-no-border': 'alert-triangle',
+
+
+
 ## Accessibility
 TBD...
 

--- a/packages/pds-ember/addon/components/pds/banner/index.js
+++ b/packages/pds-ember/addon/components/pds/banner/index.js
@@ -15,6 +15,7 @@ export default class PdsBanner extends Component {
    *   - `info-no-border`
    *   - `success`
    *   - `warning`
+   *   - `warning-no-border`
    *
    * @argument variant
    * @type {string}

--- a/packages/pds-ember/addon/components/pds/banner/utils.js
+++ b/packages/pds-ember/addon/components/pds/banner/utils.js
@@ -6,4 +6,5 @@ export const ICON_TYPES = {
   'info-no-border': 'info-circle-fill',
   'success': 'check-circle-fill',
   'warning': 'alert-triangle',
+  'warning-no-border': 'alert-triangle',
 }

--- a/packages/pds-ember/app/styles/pds/components/banner/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/banner/__config.scss
@@ -57,6 +57,12 @@ $WARNING: (
   header-color: theme.$warning-d1,
   icon-color: theme.$warning-base,
 );
+$WARNING_BORDERLESS: (
+  backgroundColor: transparent,
+  borderColor: transparent,
+  header-color: theme.$warning-d1,
+  icon-color: theme.$warning-base,
+);
 
 @mixin theme($styles) {
   /* [debug] #{$_module}@theme */
@@ -142,6 +148,10 @@ $WARNING: (
 
   &--warning {
     @include theme($WARNING);
+  }
+
+  &--warning-no-border {
+    @include theme($WARNING_BORDERLESS);
   }
 }
 


### PR DESCRIPTION
This PR adds a new type of banner, one with the warning icon but no border.

To test: Check it out under `Banner` in storybook, under `Control` there should be a Warning No Border option.