### PR TITLE
Allow ExternalLink to be used within Dropdown

### DIFF
--- a/packages/pds-ember/app/styles/pds/components/dropdown/item/link/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/dropdown/item/link/__config.scss
@@ -25,7 +25,7 @@ $_module: "PDS.Components.Dropdown.Item:Link";
 @mixin apply {
   /* [debug] #{$_module}@apply */
   @include _super.apply {
-    @include Link.apply {
+    :any-link:not(.pds-button):not(.pds--external) {
       @content;
     }
   }


### PR DESCRIPTION
This change allows for use of the ExternalLink component within Dropdown without the Dropdown component styling clashing with ExternalLink's styles