### PR TITLE
Improves ExternalLink's icon usability

### DIFF
--- a/packages/pds-ember/addon/components/pds/external-link/docs.mdx
+++ b/packages/pds-ember/addon/components/pds/external-link/docs.mdx
@@ -1,7 +1,8 @@
-import { ArgsTable } from '@storybook/addon-docs/blocks';
-export const TITLE = 'Components / External Link';
+import { ArgsTable } from "@storybook/addon-docs/blocks";
+export const TITLE = "Components / External Link";
 
 # External Link
+
 A wrapper for an HTML anchor element (`<a>`), preconfigured with the intent
 to define a hyperlink that opens in a new window or tab.
 
@@ -11,47 +12,49 @@ to define a hyperlink that opens in a new window or tab.
 - [Accessibility](#accessibility)
 - [See Also](#see-also)
 
-
 ## Usage
 
 ```handlebars
 <Pds::ExternalLink
-  @showIcon={{boolean}}
+  @iconEnd={{string ['exit']}}
+  @iconStart={{string ['']}}
+  @showIcon={{boolean [false]}}
 >
   {{! block content goes here}}
 </Pds::ExternalLink>
 ```
+
 <ArgsTable of="PdsExternalLink" />
 
-
 ## Styling
+
 ```scss
 @use "pds/components/external-link";
 ```
 
-
 ## Markup
+
 The `<Pds::ExternalLink>` component handles generation of an HTML anchor
 element (`<a>`) with the following pre-defined attributes.
 
-* `[target="_blank"]`
-* `[rel="noopener noreferrer"]`
+- `[target="_blank"]`
+- `[rel="noopener noreferrer"]`
 
 Additional HTML attributes may be added as necessary to configure markup for
 specific use cases.
 
-
 ## Accessibility
+
 TBD...
 
-
 ## See Also
-* [Link](?path=/docs/components-link--index)
-* [About `rel=noopener`: What problems does it solve?](https://mathiasbynens.github.io/rel-noopener/)
-* [Opens External Anchors Using rel="noopener"](https://developers.google.com/web/tools/lighthouse/audits/noopener)
-* Link type "noopener"
-  * [WHATWG](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener)
-  * [caniuse](https://caniuse.com/#feat=rel-noopener)
-* Link type "noreferrer"
-  * [WHATWG](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer)
-  * [caniuse](https://caniuse.com/#feat=rel-noreferrer)
+
+- [Link](?path=/docs/components-link--index)
+- [About `rel=noopener`: What problems does it solve?](https://mathiasbynens.github.io/rel-noopener/)
+- [Opens External Anchors Using rel="noopener"](https://developers.google.com/web/tools/lighthouse/audits/noopener)
+- Link type "noopener"
+  - [WHATWG](https://html.spec.whatwg.org/multipage/links.html#link-type-noopener)
+  - [caniuse](https://caniuse.com/#feat=rel-noopener)
+- Link type "noreferrer"
+  - [WHATWG](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer)
+  - [caniuse](https://caniuse.com/#feat=rel-noreferrer)

--- a/packages/pds-ember/addon/components/pds/external-link/index.hbs
+++ b/packages/pds-ember/addon/components/pds/external-link/index.hbs
@@ -5,11 +5,13 @@
   ...attributes
   data-test-external-link
 >
-  {{yield}}
-  {{#unless @hideIcon}}
-    <Pds::Icon
-      @type="exit"
-      data-test-external-link-icon
-    />
-  {{/unless}}
+  {{#if @hideIcon}}
+    {{yield}}
+  {{else if @iconStart}}
+    <Pds::Icon @type={{@iconStart}} data-test-external-link-icon />
+    {{yield}}
+  {{else}}
+    {{yield}}
+    <Pds::Icon @type={{this.iconEnd}} data-test-external-link-icon />
+  {{/if}}
 </a>

--- a/packages/pds-ember/addon/components/pds/external-link/index.js
+++ b/packages/pds-ember/addon/components/pds/external-link/index.js
@@ -21,7 +21,7 @@ import Component from '@glimmer/component'
  */
 
 /**
- * Renders an icon the left of the link text.
+ * Renders an icon to the left of the link text.
  * @argument iconStart
  * @type {?string}
  * @default ''

--- a/packages/pds-ember/addon/components/pds/external-link/index.js
+++ b/packages/pds-ember/addon/components/pds/external-link/index.js
@@ -14,14 +14,14 @@ import Component from '@glimmer/component'
 
 /**
  *
- * Renders an icon to the right of the link text.
+ * Renders an icon to the right of the block content.
  * @argument iconEnd
  * @type {?string}
  * @default 'exit'
  */
 
 /**
- * Renders an icon to the left of the link text.
+ * Renders an icon to the left of the block content.
  * @argument iconStart
  * @type {?string}
  * @default ''

--- a/packages/pds-ember/addon/components/pds/external-link/index.js
+++ b/packages/pds-ember/addon/components/pds/external-link/index.js
@@ -8,7 +8,26 @@ import Component from '@glimmer/component'
  * Controls visibility of the trailing icon.
  *
  * @argument hideIcon
- * @type {boolean}
+ * @type {?boolean}
  * @default false
  */
-export default class PdsExternalLink extends Component {}
+
+/**
+ *
+ * Renders an icon to the right of the link text.
+ * @argument iconEnd
+ * @type {?string}
+ * @default 'exit'
+ */
+
+/**
+ * Renders an icon the left of the link text.
+ * @argument iconStart
+ * @type {?string}
+ * @default ''
+ */
+export default class PdsExternalLink extends Component {
+  get iconEnd() {
+    return this.args.iconEnd || 'exit'
+  }
+}

--- a/packages/pds-ember/addon/components/pds/external-link/stories/index.stories.js
+++ b/packages/pds-ember/addon/components/pds/external-link/stories/index.stories.js
@@ -1,40 +1,51 @@
 import ICONS from '@hashicorp/structure-icons/dist/index';
-import hbs from 'htmlbars-inline-precompile'
-import DocsPage, { TITLE } from '../docs.mdx'
+import hbs from 'htmlbars-inline-precompile';
+import DocsPage, { TITLE } from '../docs.mdx';
 
 export default {
   title: TITLE,
   component: 'PdsExternalLink',
   parameters: { docs: { page: DocsPage } },
-}
+};
 
 export const Index = (args) => ({
   template: hbs`
     <Pds::ExternalLink
       href="#"
       @hideIcon={{hideIcon}}
+      @iconEnd={{iconEnd}}
+      @iconStart={{iconStart}}
     >
-      {{#if iconType}}
-        <Pds::Icon @type={{iconType}} />
-      {{/if}}
       External Link
     </Pds::ExternalLink>
   `,
   context: args,
-})
+});
 Index.argTypes = {
   hideIcon: {
     name: '@hideIcon',
+    description: '(optional) hides icon',
   },
-  iconType: {
-    name: 'leading icon',
-    description: '(optional) applied via `<Pds::Icon>` in block content',
+  iconStart: {
+    name: '@iconStart',
+    description:
+      '(optional) applied via `<Pds::Icon>` in block content at start',
     control: {
       type: 'select',
       options: ICONS,
     },
   },
-}
+  iconEnd: {
+    name: '@iconEnd',
+    description: '(optional) applied via `<Pds::Icon>` in block content at end',
+    control: {
+      type: 'select',
+      options: ICONS,
+    },
+  },
+};
 Index.args = {
   hideIcon: false,
-}
+  iconStart: '',
+  iconEnd: '',
+};

--- a/packages/pds-ember/tests/integration/components/external-link-test.js
+++ b/packages/pds-ember/tests/integration/components/external-link-test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars'
 const ROOT = '[data-test-external-link]'
 const ICON = '[data-test-external-link-icon]'
 
-module.only('Integration | Components.ExternalLink', function(hooks) {
+module('Integration | Components.ExternalLink', function(hooks) {
   setupRenderingTest(hooks)
 
   test('it renders inline', async function(assert) {

--- a/packages/pds-ember/tests/integration/components/external-link-test.js
+++ b/packages/pds-ember/tests/integration/components/external-link-test.js
@@ -6,7 +6,7 @@ import { hbs } from 'ember-cli-htmlbars'
 const ROOT = '[data-test-external-link]'
 const ICON = '[data-test-external-link-icon]'
 
-module('Integration | Components.ExternalLink', function(hooks) {
+module.only('Integration | Components.ExternalLink', function(hooks) {
   setupRenderingTest(hooks)
 
   test('it renders inline', async function(assert) {
@@ -53,6 +53,42 @@ module('Integration | Components.ExternalLink', function(hooks) {
       .dom(ICON)
       .doesNotExist()
       .isNotVisible()
+  })
+
+  test('it renders icon at start', async function (assert) {
+    await render(hbs`
+      <Pds::ExternalLink @iconStart="docs">
+        <span data-test-my-link>My Link</span>
+      </Pds::ExternalLink>
+    `)
+
+    assert
+      .dom(`${ROOT} >:first-child`)
+      .exists()
+      .hasAttribute('data-test-external-link-icon')
+
+    assert
+      .dom(`${ROOT} >:last-child`)
+      .exists()
+      .hasAttribute('data-test-my-link')
+  })
+
+  test('it renders icon at end', async function (assert) {
+    await render(hbs`
+      <Pds::ExternalLink @iconEnd="docs">
+        <span data-test-my-link>My Link</span>
+      </Pds::ExternalLink>
+    `)
+
+    assert
+      .dom(`${ROOT} >:last-child`)
+      .exists()
+      .hasAttribute('data-test-external-link-icon')
+
+    assert
+      .dom(`${ROOT} >:first-child`)
+      .exists()
+      .hasAttribute('data-test-my-link')
   })
 })
 


### PR DESCRIPTION
These changes make the component's interface align more to that of the Button
component, and allow for an icon to be placed at the beginning or end of
the block content.

This does not contain any breaking changes. The component still defaults
to rendering the exit icon at the end of the block content as it did
prior.