### PR TITLE
refactoring spike for accessibility conformance

### DIFF
--- a/packages/pds-ember/addon/components/pds/dropdown/dialog/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/dialog/index.hbs
@@ -1,7 +1,14 @@
-<div
+{{#if (has-block)}}
+<ul
   class="pds-dropdownDialog {{if @isOpen 'pds--open'}}"
   ...attributes
   data-test-dropdown-dialog
 >
+  {{!-- {{yield (hash
+    ListItem=(component 'pds/dropdown/list-item')
+  )}} --}}
   {{yield}}
-</div>
+</ul>
+{{else}}
+ <p>no ul block</p>
+{{/if}}

--- a/packages/pds-ember/addon/components/pds/dropdown/dialog/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/dialog/index.hbs
@@ -1,14 +1,6 @@
-{{#if (has-block)}}
 <ul
   class="pds-dropdownDialog {{if @isOpen 'pds--open'}}"
-  ...attributes
   data-test-dropdown-dialog
 >
-  {{!-- {{yield (hash
-    ListItem=(component 'pds/dropdown/list-item')
-  )}} --}}
   {{yield}}
 </ul>
-{{else}}
- <p>no ul block</p>
-{{/if}}

--- a/packages/pds-ember/addon/components/pds/dropdown/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/index.hbs
@@ -12,5 +12,6 @@
     close=this.close
     Trigger=(component 'pds/dropdown/trigger' isOpen=this.isOpen)
     Dialog=(component 'pds/dropdown/dialog' isOpen=this.isOpen)
+    ListItem=(component 'pds/dropdown/list-item')
   )}}
 </div>

--- a/packages/pds-ember/addon/components/pds/dropdown/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/index.hbs
@@ -1,4 +1,4 @@
-<details
+<div
   class="pds-dropdown {{this.alignmentClass}} {{@attr-class}}"
   open={{this.isOpen}}
   ...attributes
@@ -12,6 +12,5 @@
     close=this.close
     Trigger=(component 'pds/dropdown/trigger' isOpen=this.isOpen)
     Dialog=(component 'pds/dropdown/dialog' isOpen=this.isOpen)
-    ListItem=(component 'pds/dropdown/list-item')
   )}}
-</details>
+</div>

--- a/packages/pds-ember/addon/components/pds/dropdown/list-item.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/list-item.hbs
@@ -1,11 +1,6 @@
-{{#if (has-block)}}
-
-  <li
-    class="pds-dropdown__listItem"
-    data-test-dropdown-list-item
-  >
-    {{yield}}
-  </li>
-{{else}}
-  No block.
-{{/if}}
+<li
+  class="pds-dropdown__listItem"
+  data-test-dropdown-list-item
+>
+  {{yield}}
+</li>

--- a/packages/pds-ember/addon/components/pds/dropdown/list-item.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/list-item.hbs
@@ -1,7 +1,11 @@
-<div
-  class="pds-dropdown__listItem"
-  ...attributes
-  data-test-dropdown-list-item
->
-  {{yield}}
-</div>
+{{#if (has-block)}}
+
+  <li
+    class="pds-dropdown__listItem"
+    data-test-dropdown-list-item
+  >
+    {{yield}}
+  </li>
+{{else}}
+  No block.
+{{/if}}

--- a/packages/pds-ember/addon/components/pds/dropdown/trigger/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/trigger/index.hbs
@@ -3,7 +3,7 @@
   NOTE: Button classes must be applied to the <summary> to get
         correct styling of :active and :focus states.
 --}}
-<summary
+<button
   class="
     pds-dropdownTrigger
     pds-button
@@ -37,5 +37,5 @@
       data-test-dropdown-trigger-icon
     />
   </span>
-</summary>
+</button>
 {{!-- template-lint-enable simple-unless --}}

--- a/packages/pds-ember/app/styles/pds/components/dropdown/dialog/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/dropdown/dialog/__config.scss
@@ -56,6 +56,8 @@ $__divider-color: theme.$borderColor--dim;
 @mixin apply {
   /* [debug] #{$_module}@apply */
   .pds-dropdownDialog {
+    margin-top: 0;
+    padding: 0;
     @content;
   }
 }

--- a/packages/pds-ember/tests/dummy/app/templates/application.hbs
+++ b/packages/pds-ember/tests/dummy/app/templates/application.hbs
@@ -10,16 +10,16 @@
     </D.Trigger>
 
     <D.Dialog>
-        <Pds::Dropdown::ListItem>
+        <D.ListItem>
           <Pds::Icon @type="bolt" />
           List Item
-        </Pds::Dropdown::ListItem>
-        <Pds::Dropdown::ListItem>
+        </D.ListItem>
+        <D.ListItem>
           <Pds::Button>Button</Pds::Button>
-        </Pds::Dropdown::ListItem>
-        <Pds::Dropdown::ListItem>
-          <Pds::CtaLink @route="index">CTA Link</Pds::CtaLink>
-        </Pds::Dropdown::ListItem>
+        </D.ListItem>
+        <D.ListItem>
+          <Pds::CtaLink @route="index">Hello Link</Pds::CtaLink>
+        </D.ListItem>
     </D.Dialog>
     
   </Pds::Dropdown>

--- a/packages/pds-ember/tests/dummy/app/templates/application.hbs
+++ b/packages/pds-ember/tests/dummy/app/templates/application.hbs
@@ -1,7 +1,30 @@
 <Pds::App as |App|>
   <App.ModalArea></App.ModalArea>
 
-  <App.Header>Header</App.Header>
+  <App.Header>
+    Header
+
+  <Pds::Dropdown as |D|>
+    <D.Trigger>
+      Menu
+    </D.Trigger>
+
+    <D.Dialog>
+        <Pds::Dropdown::ListItem>
+          <Pds::Icon @type="bolt" />
+          List Item
+        </Pds::Dropdown::ListItem>
+        <Pds::Dropdown::ListItem>
+          <Pds::Button>Button</Pds::Button>
+        </Pds::Dropdown::ListItem>
+        <Pds::Dropdown::ListItem>
+          <Pds::CtaLink @route="index">CTA Link</Pds::CtaLink>
+        </Pds::Dropdown::ListItem>
+    </D.Dialog>
+    
+  </Pds::Dropdown>
+
+  </App.Header>
 
   <App.Banner>Banner</App.Banner>
 


### PR DESCRIPTION
Not for merging. 

Refactored where I could, to see what it would be like to make this component accessible. 

Three issues:
- open/close toggle doesn't work
- needs focus trap
- styling can't yet tell the difference between a list item with just text and a list item with an interactive item (so padding is not consistent)

Screenshot: 
![image](https://user-images.githubusercontent.com/4587451/153924524-439e33c3-6b85-46af-aee2-7c8e475f5732.png)
