### PR TITLE
Add HDS class names to the `:any-link:not(…)` CSS selector

### DIFF
--- a/packages/pds-ember/app/styles/pds/_overrides.scss
+++ b/packages/pds-ember/app/styles/pds/_overrides.scss
@@ -1,1 +1,3 @@
 // Strive to keep this file empty!
+
+$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive, .hds-breadcrumb__link, .hds-tag__link";

--- a/packages/pds-ember/app/styles/pds/components/link/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/__config.scss
@@ -5,6 +5,9 @@ $_module: "PDS.Components.Link";
 @use "../../theme";
 @use "../../utils/pseudo" as Pseudo;
 
+// needed for the "$hds-link-overrides-selectors" variable used below
+@use "../../overrides" as overrides;
+
 $underline-width: 1px;
 
 @mixin reset {
@@ -58,7 +61,7 @@ $underline-width: 1px;
 
 @mixin apply {
   /* [debug] #{$_module}@apply */
-  :any-link:not(.pds-button, .hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive, .hds-breadcrumb__link, .hds-tag__link) {
+  :any-link:not(.pds-button, #{overrides.$hds-link-overrides-selectors}) {
     @content;
   }
 }

--- a/packages/pds-ember/app/styles/pds/components/link/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/__config.scss
@@ -58,7 +58,7 @@ $underline-width: 1px;
 
 @mixin apply {
   /* [debug] #{$_module}@apply */
-  :any-link:not(.pds-button) {
+  :any-link:not(.pds-button, .hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive, .hds-breadcrumb__link, .hds-tag__link) {
     @content;
   }
 }


### PR DESCRIPTION
Following [the conversation in this Slack thread](https://hashicorp.slack.com/archives/CPB8GS9QT/p1656340750645769) and @jesdavpet suggestion, this PR adds the HDS classnames to the `:any-link:not(…)` CSS selector to avoid using anti-overrides to (see for example this PR https://github.com/hashicorp/cloud-ui/pull/2925) to counter the effect of that global CSS declaration on the HDS components (the declaration has a higher specificity!) 

<img width="400" alt="screenshot_1597" src="https://user-images.githubusercontent.com/686239/176027611-83f50a2f-8584-4caf-a677-5caeb1797009.png">

**Notice**: I have decided to extract the CSS selectors in a Sass variable, so it can be imported via `@use` in Cloud UI. In this way it becomes a centralized place where these selectors are added/updated, without the need to manually update alsoall the local `:any-link:not(.pds-button)` declarations in Cloud UI. 

```
// needed for the "$hds-link-overrides-selectors" variable used below
@use "pds/overrides" as overrides;

// make all link semi-bold weight
:any-link:not(.pds-button, #{overrides.$hds-link-overrides-selectors}) {
  font-weight: Font.weight('Semi Bold');
  transition: color ease-in-out 75ms;
}
```