### PR TITLE
Remove `Pds:Icon` as dependency for Structure

### DIFF
--- a/packages/pds-ember/.storybook/main.js
+++ b/packages/pds-ember/.storybook/main.js
@@ -1,6 +1,8 @@
 const namedBlockPolyfill = require('ember-named-blocks-polyfill/lib/named-blocks-polyfill-plugin');
 const path = require('path');
 
+const flightSprite = require('@hashicorp/flight-icons/svg-sprite/svg-sprite-module');
+
 module.exports = {
   emberOptions: {
     polyfills: [namedBlockPolyfill],
@@ -29,4 +31,8 @@ module.exports = {
     };
     return config;
   },
+  previewHead: (head) => `
+    ${head}
+    ${flightSprite}
+  `,
 };

--- a/packages/pds-ember/addon/components/pds/avatar/index.hbs
+++ b/packages/pds-ember/addon/components/pds/avatar/index.hbs
@@ -12,8 +12,10 @@
         data-test-avatar-img
       />
     {{else}}
-      <Pds::Icon
-        @type="user-square-outline"
+      <FlightIcon
+        @name="user"
+        @size="24"
+        @stretched={{true}}
         aria-label={{this.alt}}
         data-test-avatar-icon
       />

--- a/packages/pds-ember/addon/components/pds/button/index.hbs
+++ b/packages/pds-ember/addon/components/pds/button/index.hbs
@@ -16,8 +16,8 @@
   data-test-button
 >
   {{#if @iconStart}}
-    <Pds::Icon
-      @type={{@iconStart}}
+    <FlightIcon
+      @name={{@iconStart}}
       class="pds-button__iconStart"
       data-test-button-icon-start
     />
@@ -36,8 +36,8 @@
   {{/if}}
 
   {{#if @iconEnd}}
-    <Pds::Icon
-      @type={{@iconEnd}}
+    <FlightIcon
+      @name={{@iconEnd}}
       class="pds-button__iconEnd"
       data-test-button-icon-end
     />

--- a/packages/pds-ember/addon/components/pds/button/index.js
+++ b/packages/pds-ember/addon/components/pds/button/index.js
@@ -27,7 +27,7 @@ import { getVariantClass } from './utils';
  */
 
 /**
- * `@type` argument for the second of two [Icon](?path=/docs/components-icon--index)
+ * `@type` argument for the second of two [FlightIcon](https://flight-hashicorp.vercel.app/)
  * components (rendered after block content).
  *
  * _(default: `''`)_
@@ -40,7 +40,7 @@ import { getVariantClass } from './utils';
  */
 
 /**
- * `@type` argument for the first of two [Icon](?path=/docs/components-icon--index)
+ * `@type` argument for the first of two [FlightIcon](https://flight-hashicorp.vercel.app/)
  * components (rendered before block content).
  *
  * _(default: `''`)_

--- a/packages/pds-ember/addon/components/pds/checkbox-field/facade/index.hbs
+++ b/packages/pds-ember/addon/components/pds/checkbox-field/facade/index.hbs
@@ -3,9 +3,14 @@
   ...attributes
   data-test-checkbox-facade
 >
-  <Pds::Icon
-    @type="check-plain"
+  <svg
     class="pds-checkboxFacade__tick"
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
     data-test-checkbox-facade-tick
-  />
+  >
+      <path fill-rule="evenodd" clip-rule="evenodd" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z" fill="currentColor"></path>
+  </svg>
 </div>

--- a/packages/pds-ember/addon/components/pds/dropdown/trigger/index.hbs
+++ b/packages/pds-ember/addon/components/pds/dropdown/trigger/index.hbs
@@ -31,8 +31,8 @@
       </span>
     {{/if}}
 
-    <Pds::Icon
-      @type={{this.icon}}
+    <FlightIcon
+      @name={{this.icon}}
       class="pds-button__iconEnd pds-dropdownTrigger__icon"
       data-test-dropdown-trigger-icon
     />

--- a/packages/pds-ember/addon/components/pds/error-message/index.hbs
+++ b/packages/pds-ember/addon/components/pds/error-message/index.hbs
@@ -1,4 +1,4 @@
 <div class="pds-errorMessage" ...attributes data-test-root>
-  <Pds::Icon @type="cancel-square-fill" />
+  <FlightIcon class="pds-errorMessage__icon" @name="x-square-fill" @stretched={{true}} />
   <p>{{yield}}</p>
 </div>

--- a/packages/pds-ember/addon/components/pds/select/facade.hbs
+++ b/packages/pds-ember/addon/components/pds/select/facade.hbs
@@ -4,6 +4,6 @@
   data-test-root
 >
   <div class="pds-selectFacade__grabber" data-test-grabber>
-    <Pds::Icon @type="unfold-more" data-test-grabber-icon />
+    <FlightIcon @name="caret" data-test-grabber-icon />
   </div>
 </div>

--- a/packages/pds-ember/app/styles/pds/components/checkbox-field/facade/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/checkbox-field/facade/__config.scss
@@ -86,6 +86,8 @@ $DISABLED_ACTIVE: map.merge($DISABLED, (
 
   &__tick {
     visibility: $__tick-visibility;
+    height: 1em;
+    width: 1em;
   }
 
   @include theme($VALID);

--- a/packages/pds-ember/app/styles/pds/components/error-message/_config.scss
+++ b/packages/pds-ember/app/styles/pds/components/error-message/_config.scss
@@ -22,6 +22,13 @@ $lineHeight: var(--pds-errorMessage-lineHeight);
   display: flex;
   padding: 0;
 
+  .pds-errorMessage__icon {
+    flex-shrink: 0;
+    height: 1em;
+    width: 1em;
+    margin-top: 0.1em; // better visual alignment with the text (it has a line-height of 1.2)
+  }
+
   // ensure child margins don't affect whitespace of the component
   > * {
     margin: 0;

--- a/packages/pds-ember/docs/install.stories.mdx
+++ b/packages/pds-ember/docs/install.stories.mdx
@@ -13,40 +13,8 @@ ember install @hashicorp/pds-ember
 This will install NPM dependencies automatically, but additional configuration
 may be required.
 
-* [Icons](#icons)
 * [Sass](#sass)
-
-
-## Icons
-(`ember-svg-jar` and `@hashicorp/structure-icons` are automatically installed
-as dependencies of `@hashicorp/pds-ember`)
-
-The `<Pds::Icon>` component uses `ember-svg-jar` to inline SVG icons in HTML
-markup, and multiple component templates use icons that are provided by
-`@hashicorp/structure-icons`.  However, these icons aren't loaded by default,
-so you'll need to add them to the `svgJar.paths` configuration.
-
-
-```javascript
-/* ember-cli-build.js */
-
-module.exports = function(defaults) {
-  let app = new EmberAddon(defaults, {
-    svgJar: {
-      paths: [
-        // exact path may vary depending on project file structure
-        'node_modules/@hashicorp/structure-icons/dist',
-      ]
-    }
-  })
-
-  return app.toTree()
-}
-```
-
-See [@hashicorp/structure-icons](https://github.com/hashicorp/structure-icons#ember-svg-jar)
-for additional configuration details.
-
+* [Icons](#icons)
 
 
 ## Sass
@@ -81,3 +49,10 @@ module.exports = function(defaults) {
   return app.toTree()
 }
 ```
+
+## Icons
+
+(`@hashicorp/ember-flight-icons` is automatically installed as dependency of `@hashicorp/pds-ember`)
+
+Pds-Ember components use `<FlightIcon>` addon to show icons from the Flight icons set (for more details see: https://flight-hashicorp.vercel.app/).
+

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -62,6 +62,7 @@
     "@embroider/test-setup": "^0.37.0",
     "@glimmer/component": "^1.0.4",
     "@glimmer/tracking": "^1.0.4",
+    "@hashicorp/flight-icons": "^2.10.0",
     "@storybook/addon-docs": "^6.5.12",
     "@storybook/addon-essentials": "^6.5.12",
     "@storybook/addon-knobs": "^6.1.0",

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
+    "@hashicorp/ember-flight-icons": "^2.0.12",
     "@hashicorp/structure-icons": "^1.9.2",
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",

--- a/packages/pds-ember/tests/dummy/app/components/docs/global-header/index.hbs
+++ b/packages/pds-ember/tests/dummy/app/components/docs/global-header/index.hbs
@@ -42,7 +42,7 @@
   <:secondary-nav>
     <a href="#">Link</a>
     <a href="#" class="pds--iconOnly">
-      <Pds::Icon @type="help-circle-outline" />
+      <FlightIcon @name="help" @size="24" />
       <span class="pds--visuallyHidden">Icon Link</span>
     </a>
   </:secondary-nav>

--- a/packages/pds-ember/tests/dummy/app/templates/index.hbs
+++ b/packages/pds-ember/tests/dummy/app/templates/index.hbs
@@ -10,35 +10,3 @@
   allow our release planning to reach the predictable story beyond the release
   plan. We must easily block the prioritized PR deadlines!
 </p>
-
-<dl>
-  <dt>test-icon</dt>
-  <dd>
-    text before
-    <Pds::Icon @type="test-icon" />
-    text after
-  </dd>
-
-  <dt>cancel-square-fill</dt>
-  <dd>
-    text before
-    <Pds::Icon @type="cancel-square-fill" />
-    text after
-  </dd>
-
-  <dt>bolt</dt>
-  <dd>
-    before
-    <Pds::Icon @type="logo-bitbucket-color" />
-    between
-    <Pds::Icon @type="cancel-square-fill" />
-    after
-  </dd>
-
-  <dt>dne-icon</dt>
-  <dd>
-    text before
-    <Pds::Icon @type="dne-icon" />
-    text after
-  </dd>
-</dl>

--- a/packages/pds-ember/tests/integration/components/avatar/index-test.js
+++ b/packages/pds-ember/tests/integration/components/avatar/index-test.js
@@ -32,7 +32,7 @@ module('Integration | Components.Avatar', function (hooks) {
     assert
       .dom(ICON)
       .exists()
-      .hasAttribute('data-test-icon-type', 'user-square-outline')
+      .hasAttribute('data-test-icon', 'user')
       .hasAttribute(
         'aria-label',
         DEFAULT_ALT,
@@ -45,7 +45,7 @@ module('Integration | Components.Avatar', function (hooks) {
     assert
       .dom(ICON)
       .exists()
-      .hasAttribute('data-test-icon-type', 'user-square-outline')
+      .hasAttribute('data-test-icon', 'user')
       .hasAttribute(
         'aria-label',
         custom_alt,

--- a/packages/pds-ember/tests/integration/components/button/button-test.js
+++ b/packages/pds-ember/tests/integration/components/button/button-test.js
@@ -76,8 +76,8 @@ module('Integration | Components.Button', function (hooks) {
         'does not have "icon end" modifier CSS class'
       );
 
-    // @iconStart='test-icon'
-    this.set('iconStart', 'test-icon');
+    // @iconStart='docs-link'
+    this.set('iconStart', 'docs-link');
     // start icon only
     assert.dom(ICON_START).exists();
     assert.dom(ICON_END).doesNotExist();
@@ -89,8 +89,8 @@ module('Integration | Components.Button', function (hooks) {
         'does not have "icon end" modifier CSS class'
       );
 
-    // @iconEnd='test-icon'
-    this.set('iconEnd', 'test-icon');
+    // @iconEnd='docs-link'
+    this.set('iconEnd', 'docs-link');
     // both start and end icons
     assert.dom(ICON_START).exists();
     assert.dom(ICON_END).exists();

--- a/packages/pds-ember/tests/integration/components/button/stories/layouts/index.stories.js
+++ b/packages/pds-ember/tests/integration/components/button/stories/layouts/index.stories.js
@@ -28,7 +28,7 @@ export const IconOnly_ariaLabel = () => ({
   template: hbs`
     <Pds::Button
       @compact={{isCompact}}
-      @iconStart="test-icon"
+      @iconStart="docs-link"
       aria-label="Text"
     />
   `,
@@ -41,7 +41,7 @@ export const IconOnly_visuallyHidden_label = () => ({
     <Pds::Button
       @compact={{isCompact}}
       @hideText={{true}}
-      @iconStart="test-icon"
+      @iconStart="docs-link"
     >
       Text
     </Pds::Button>
@@ -55,8 +55,8 @@ export const TwoIcons_withoutBlock = () => ({
   template: hbs`
     <Pds::Button
       @compact={{isCompact}}
-      @iconEnd="test-icon"
-      @iconStart="test-icon"
+      @iconEnd="docs-link"
+      @iconStart="docs-link"
       aria-label="Text"
     />
   `,
@@ -69,8 +69,8 @@ export const TwoIcons_withBlock = () => ({
     <Pds::Button
       @compact={{isCompact}}
       @hideText={{true}}
-      @iconEnd="test-icon"
-      @iconStart="test-icon"
+      @iconEnd="docs-link"
+      @iconStart="docs-link"
     >
       Text
     </Pds::Button>
@@ -83,7 +83,7 @@ export const TextBeforeIcon = () => ({
   template: hbs`
     <Pds::Button
       @compact={{isCompact}}
-      @iconEnd="test-icon"
+      @iconEnd="docs-link"
     >
       Text
     </Pds::Button>
@@ -96,7 +96,7 @@ export const TextAfterIcon = () => ({
   template: hbs`
     <Pds::Button
       @compact={{isCompact}}
-      @iconStart="test-icon"
+      @iconStart="docs-link"
     >
       Text
     </Pds::Button>
@@ -109,8 +109,8 @@ export const TextBetweenIcons = () => ({
   template: hbs`
     <Pds::Button
       @compact={{isCompact}}
-      @iconEnd="test-icon"
-      @iconStart="test-icon"
+      @iconEnd="docs-link"
+      @iconStart="docs-link"
     >
       Text
     </Pds::Button>
@@ -123,8 +123,8 @@ export const LengthyContent = () => ({
   template: hbs`
     <Pds::Button
       @compact={{isCompact}}
-      @iconEnd="test-icon"
-      @iconStart="test-icon"
+      @iconEnd="docs-link"
+      @iconStart="docs-link"
     >
       Text with lengthy content.
       The quick brown fox jumps over the lazy dog.

--- a/packages/pds-ember/tests/integration/components/cta-link/stories/index.stories.js
+++ b/packages/pds-ember/tests/integration/components/cta-link/stories/index.stories.js
@@ -1,6 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
 import DocsPage, { TITLE } from '../docs.mdx';
-import ICONS from '@hashicorp/structure-icons/dist/index';
 
 export default {
   title: TITLE,
@@ -38,19 +37,11 @@ export const WithIcon = (args) => ({
     <Docs::CtaLink class="pds--iconEnd" @variant={{variant}}>
       {{! text MUST be wrapped in <span> }}
       <span>Action</span>
-      <Pds::Icon @type={{icon}} />
+      <FlightIcon @name={{icon}} />
     </Docs::CtaLink>
   `,
   context: args,
 });
-WithIcon.argTypes = {
-  icon: {
-    control: {
-      type: 'select',
-      options: ICONS,
-    },
-  },
-};
 WithIcon.args = {
   icon: 'chevron-right',
 };

--- a/packages/pds-ember/tests/integration/components/dropdown/trigger/stories/index.stories.js
+++ b/packages/pds-ember/tests/integration/components/dropdown/trigger/stories/index.stories.js
@@ -1,8 +1,6 @@
 import hbs from 'htmlbars-inline-precompile';
 import DocsPage, { TITLE } from '../docs.mdx';
 
-import ICONS from '@hashicorp/structure-icons/dist/index';
-
 import {
   DEFAULT_VARIANT,
   VARIANT_CLASSES,
@@ -18,10 +16,7 @@ export default {
     hideText: {},
     icon: {
       defaultValue: 'chevron-down',
-      control: {
-        type: 'select',
-        options: ICONS,
-      },
+      control: 'text',
     },
     variant: {
       defaultValue: DEFAULT_VARIANT,

--- a/packages/pds-ember/tests/integration/components/link/stories/index.stories.js
+++ b/packages/pds-ember/tests/integration/components/link/stories/index.stories.js
@@ -1,6 +1,5 @@
 import hbs from 'htmlbars-inline-precompile';
 import DocsPage, { TITLE } from '../docs.mdx';
-import Icons from '@hashicorp/structure-icons/dist/index';
 
 export default {
   title: TITLE,
@@ -10,13 +9,7 @@ export default {
 export const Index = (args) => ({
   template: hbs`
     <a href="#" class="{{variantClass}}">
-      {{#if iconStart}}
-        <Pds::Icon @type={{iconStart}} />
-      {{/if}}
       {{text}}
-      {{#if iconEnd}}
-        <Pds::Icon @type={{iconEnd}} />
-      {{/if}}
     </a>
   `,
   context: args,
@@ -33,41 +26,11 @@ Index.argTypes = {
       },
     },
   },
-  iconStart: {
-    control: {
-      type: 'select',
-      options: ['', ...Icons],
-    },
-  },
-  iconEnd: {
-    control: {
-      type: 'select',
-      options: ['', ...Icons],
-    },
-  },
   text: {
     defaultValue: 'Link Text',
     control: 'text',
   },
 };
-
-export const WithLeadingIcon = () => ({
-  template: hbs`
-    <a href="#">
-      <Pds::Icon @type="info-circle-fill" />
-      Read More
-    </a>
-  `,
-});
-
-export const WithTrailingIcon = () => ({
-  template: hbs`
-    <a href="#">
-      Read More
-      <Pds::Icon @type="exit" />
-    </a>
-  `,
-});
 
 export const WithInlineCode = () => ({
   template: hbs`

--- a/packages/pds-ember/tests/integration/components/toolbar/stories/1_patterns.stories.js
+++ b/packages/pds-ember/tests/integration/components/toolbar/stories/1_patterns.stories.js
@@ -22,7 +22,7 @@ export const Lists = () => ({
       <T.End>
         <Docs::CtaLink @variant="ghost" class="pds--iconEnd">
           <span>Create Item</span>
-          <Pds::Icon @type="plus-plain" />
+          <FlightIcon @name="plus" />
         </Docs::CtaLink>
       </T.End>
     </Pds::Toolbar>
@@ -54,7 +54,7 @@ export const Details = () => ({
 
         <Docs::CtaLink @variant="ghost" class="pds--iconEnd">
           <span>Edit Item</span>
-          <Pds::Icon @type="chevron-right" />
+          <FlightIcon @name="chevron-right" />
         </Docs::CtaLink>
       </T.End>
     </Pds::Toolbar>

--- a/packages/pds-ember/tests/integration/modifiers/tooltip/docs.mdx
+++ b/packages/pds-ember/tests/integration/modifiers/tooltip/docs.mdx
@@ -17,12 +17,12 @@ You can view the modifier source file [here](https://github.com/hashicorp/struct
 ## Handlebars Usage
 
 ```handlebars
-  <Pds::Icon 
-    @type='lock-closed-fill' 
-    {{tooltip 
-        'this is a tooltip' 
-         options=(hash 
-                    placement="bottom" 
+  <FlightIcon
+    @name='lock-fill'
+    {{tooltip
+        'this is a tooltip'
+         options=(hash
+                    placement="bottom"
                     offset=(array 0 5)
                   )
     }}

--- a/packages/pds-ember/tests/integration/modifiers/tooltip/stories/index.stories.js
+++ b/packages/pds-ember/tests/integration/modifiers/tooltip/stories/index.stories.js
@@ -12,8 +12,8 @@ const CONFIG = {
 const Default = () => ({
   template: hbs`
       <p style="text-align:center; padding: 40px;">
-        <Pds::Icon
-          @type='lock-closed-fill'
+        <FlightIcon
+          @name='lock-fill'
           {{tooltip 'This peering connection is locked due to a dependency. ' options=(hash placement=tippyPlacement showOnCreate=tippyShowOnCreate offset=(array tippySkidding tippyDistance))}}
         />
       </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5053,6 +5053,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hashicorp/ember-flight-icons@npm:^2.0.12":
+  version: 2.0.12
+  resolution: "@hashicorp/ember-flight-icons@npm:2.0.12"
+  dependencies:
+    "@hashicorp/flight-icons": ^2.10.0
+    ember-cli-babel: ^7.26.11
+    ember-cli-htmlbars: ^6.0.1
+  peerDependencies:
+    ember-test-selectors: ^6.0.0
+  checksum: 86531a823bfb3b38c041ac716986e385197ea37ac85fbec9f469d533838a7dcd33f9e920e9544fa188295eedb75e4dbc772e1fcddffb617a82fc04d06f9aebae
+  languageName: node
+  linkType: hard
+
+"@hashicorp/flight-icons@npm:^2.10.0":
+  version: 2.10.0
+  resolution: "@hashicorp/flight-icons@npm:2.10.0"
+  checksum: ef1af01d052d0cf463f3de4e8511e15a09fc0608fabb175cce0389efe530f607584724b72c1a1e56d7dfe789f9090673f4c30725b6c51a4727c871731a6fd826
+  languageName: node
+  linkType: hard
+
 "@hashicorp/pds-ember@workspace:packages/pds-ember":
   version: 0.0.0-use.local
   resolution: "@hashicorp/pds-ember@workspace:packages/pds-ember"
@@ -5063,6 +5083,7 @@ __metadata:
     "@embroider/test-setup": ^0.37.0
     "@glimmer/component": ^1.0.4
     "@glimmer/tracking": ^1.0.4
+    "@hashicorp/ember-flight-icons": ^2.0.12
     "@hashicorp/structure-icons": ^1.9.2
     "@storybook/addon-docs": ^6.5.12
     "@storybook/addon-essentials": ^6.5.12

--- a/yarn.lock
+++ b/yarn.lock
@@ -5084,6 +5084,7 @@ __metadata:
     "@glimmer/component": ^1.0.4
     "@glimmer/tracking": ^1.0.4
     "@hashicorp/ember-flight-icons": ^2.0.12
+    "@hashicorp/flight-icons": ^2.10.0
     "@hashicorp/structure-icons": ^1.9.2
     "@storybook/addon-docs": ^6.5.12
     "@storybook/addon-essentials": ^6.5.12


### PR DESCRIPTION
### Description

The intent of this PR is to remove all the usages of `Pds::Icon` _within_ the repo. Once this PR is merged a new version of Structure  will be released, adopted in Cloud UI (with the needed changes/fixes that are required by the update), and only at that point we will proceed with the complete removal and deprecation of the `Pds::Icon` component itself from the repo (this will be done in a follow-up PR, obviusly).

### Changes

In this PR I have:
- **added the `@hashicorp/ember-flight-icons` package as dependency** (so we can use the `<FlightIcon>` component)
  - to be able to view the icons in Storybook, we need to injected the Flight icons sprite in the Storybook page's `<head>` element; this has been done using [the `previewHead` function](https://storybook.js.org/docs/react/addons/writing-presets#previewmanager-templates) 
  - notice: I had to add `@hashicorp/flight-icons` as dev-dependency otherwise the linter would complain that in `.main.js` the `require()` would be “extraneous”
- updated the markdown with instructions for the “install” of the `Pds::Ember` package
- removed sample icons from main `tests/dummy` app template (that page us useless)
- **`Pds::Avatar` component** → replaced `Pds::Icon` with `FlightIcon`
  - ⚠️ Notice: as agreed with @heatherlarsen we have replaced the square "user" icon with a generic "user" icon without a border around it; this is probably OK because in HCP every user has a gravatar image ([see thread](https://hashicorp.slack.com/archives/CPB8GS9QT/p1663755985050219))
- **`Pds::ErrorMessage` component** → replaced `Pds::Icon` with `FlightIcon`
- **`Pds::Select` component** → replaced `Pds::Icon` with `FlightIcon` in the component “facade”
- **`Pds::Dropdown` component** → replaced `Pds::Icon` with `FlightIcon` in the "trigger" sub-component
- **`Pds::Button` component** → replaced `Pds::Icon` with `FlightIcon`
- **`Pds::GlobalHeader` component** → updated the docs/stories  to use `FlightIcon` instead of `Pds::Icon`
- **`Pds::CheckboxField` component** → replaced `Pds::Icon` with embedded SVG in the component “facade”
  - in this specific case I didn’t use the `FlightIcon` component because the corresponding icon `check` would touch the bounding box of the container, and would require some heavy refactoring; so I’ve decided that it was easier/better to directly embed the SVG (there are just a few instances of `Pds::CheckboxField` in Cloud UI, and by the time this PR will land they will likely have already been replaced with the equivalent HDS component)
- **`Tooltip` modifier** → updated the docs/stories  to use `FlightIcon` instead of `Pds::Icon`
- **`Toolbar` component** → updated the docs/stories  to use `FlightIcon` instead of `Pds::Icon`
- **`CtaLink` component** → updated the docs/stories  to use `FlightIcon` instead of `Pds::Icon`
- **`Link` "component"** → updated the docs/stories  to use `FlightIcon` instead of `Pds::Icon` (this is not technically a component, it's just styling via CSS)

### Testing

I have symlinked my local directory `package/pds-ember` to the `cloud-ui/node_modules/@hashicorp/pds-ember` folder in Cloud UI, run the application and tested that everything worked as expected.

### Relevant links
- Epic in Jira: https://hashicorp.atlassian.net/browse/HDS-477

### 🚧 TODOs

Once this PR is merged and the new Structure version is adopted in Cloud UI:

- **`Pds::Button`** 
  - [x] check all the instances that have a `@iconStart` and/or `@iconEnd` argument, and replace the name of the icon according to [the pre-defined mapping](https://github.com/hashicorp/design-system/blob/main/packages/flight-icons/structure-mappings.json) (but consider there may be exceptions, so there may be a need to check visually the outcome in some cases, and validate with product designers).
    - I have run a codemod (see below) on the entire Cloud UI codebase to check for such instances but found zero occurrences of button with `@iconStart/iconEnd` arguments
- **`Pds::Dropdown`** 
  - [x] make sure that if there are instances in which the `Pds::Dropdown::Trigger` has a custom `@icon` argument, the name of icon is updated to use the Flight icon instead of the Structure one (you can search for `/.Trigger/`, case sensitive).
     - the only occurrence I've found is in this file `packages/cloud-ui-core/addon/components/more-menu/index.hbs` but the Structure icon names used in the `Trigger` are `more-horizontal` and `chevron-down` which are the same in Flight, so no need to update the code, it just works.

---

Codemod used to check `<Pds::Button>` instances with `@iconStart/@iconEnd` arguments:
```
module.exports = function ({ source, path }, { parse, visit }) {
  const ast = parse(source);

  return visit(ast, (env) => {
    let { builders } = env.syntax;

    return {
      ElementNode(node) {
        if (node.tag.toLowerCase() === 'pds::button') {
          const hasIconArg = node.attributes.find(
            (a) => a.name === '@iconStart' || a.name === '@iconEnd'
          );
          if (hasIconArg) {
            console.info(
              'Found <Pds::Button> with @iconStart/@iconEnd argument',
              `\nFILE: "${path}"`
            );
          }
        }
      },
    };
  });
};

module.exports.type = 'hbs';
```