### PR TITLE
bugfix: remove re-export of the deleted copyright component

### DIFF
--- a/packages/pds-ember/app/components/pds/copyright.js
+++ b/packages/pds-ember/app/components/pds/copyright.js
@@ -1,1 +1,0 @@
-export { default } from '@hashicorp/pds-ember/components/pds/copyright';


### PR DESCRIPTION
The re-export of the now-inlined `Pds::Copyright` still existed (removed [here](https://github.com/hashicorp/structure/pull/119)). This PR removes the unnecessary re-export.