### PR TITLE
Quick patch to update the `hds-link-overrides-selectors` + Bump `@hashicorp/pds-ember` to version `2.4.1` 

### DIFF
--- a/packages/pds-ember/app/styles/pds/_overrides.scss
+++ b/packages/pds-ember/app/styles/pds/_overrides.scss
@@ -1,3 +1,3 @@
 // Strive to keep this file empty!
 
-$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-breadcrumb__link, .hds-tag__link";
+$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control";

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/pds-ember",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Ember addon for building Structure-styled UIs",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Updated the selector in `$hds-link-overrides-selectors` Sass variable to include links in `Pagination` “navigation controls”.

The component is being adopted in Cloud UI (see https://github.com/hashicorp/cloud-ui/pull/4725), but the styles conflict with the `any-link` global selector.

<img width="1301" alt="screenshot_2328" src="https://user-images.githubusercontent.com/686239/217080541-0f333569-0f12-4539-a95b-8993606b7438.png">

This small PRs updates the selector and bumps the version as patch (I will merge without review so I am not blocked in the PR for Cloud UI, I'm confident there are no issues in the PR).