### PR TITLE
Update `$hds-link-overrides-selectors` and bump `@hashicorp/pds-ember` to `3.0.1`

### DIFF
--- a/packages/pds-ember/app/styles/pds/_overrides.scss
+++ b/packages/pds-ember/app/styles/pds/_overrides.scss
@@ -5,4 +5,4 @@
 
 // Strive to keep this file empty!
 
-$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control";
+$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control";

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/pds-ember",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Ember addon for building Structure-styled UIs",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Update `$hds-link-overrides-selectors` to add `hds-dropdown-list-item--variant-interactive` as we are renaming `hds-dropdown-list-item--interactive` to `hds-dropdown-list-item--variant-interactive` in https://github.com/hashicorp/design-system/pull/1185.

A follow-up PR will be raised to remove `hds-dropdown-list-item--interactive`.

[Jira ticket](https://hashicorp.atlassian.net/browse/HDS-1687)