### PR TITLE
Update `$hds-link-overrides-selectors` and bump `@hashicorp/pds-ember` to `3.0.2`

### DIFF
--- a/packages/pds-ember/app/styles/pds/_overrides.scss
+++ b/packages/pds-ember/app/styles/pds/_overrides.scss
@@ -5,4 +5,4 @@
 
 // Strive to keep this file empty!
 
-$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control";
+$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control, .hds-side-nav__home-link, .hds-side-nav__icon-button, .hds-side-nav__list-item-link, .ember-a11y-refocus-skip-link";

--- a/packages/pds-ember/app/styles/pds/_overrides.scss
+++ b/packages/pds-ember/app/styles/pds/_overrides.scss
@@ -5,4 +5,4 @@
 
 // Strive to keep this file empty!
 
-$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--interactive > a, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control, .hds-side-nav__home-link, .hds-side-nav__icon-button, .hds-side-nav__list-item-link, .ember-a11y-refocus-skip-link";
+$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control, .hds-side-nav__home-link, .hds-side-nav__icon-button, .hds-side-nav__list-item-link, .ember-a11y-refocus-skip-link";

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/pds-ember",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Ember addon for building Structure-styled UIs",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Updated `$hds-link-overrides-selectors` to add  to include CSS class names for `SideNav` elements: 
- `.hds-side-nav__home-link`
- `.hds-side-nav__icon-button`
- `.hds-side-nav__list-item-link`
- `.ember-a11y-refocus-skip-link`