### PR TITLE
Add cut list item to link override

### DIFF
--- a/packages/pds-ember/app/styles/pds/_overrides.scss
+++ b/packages/pds-ember/app/styles/pds/_overrides.scss
@@ -5,4 +5,5 @@
 
 // Strive to keep this file empty!
 
-$hds-link-overrides-selectors: ".hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control, .hds-side-nav__home-link, .hds-side-nav__icon-button, .hds-side-nav__list-item-link, .ember-a11y-refocus-skip-link";
+$hds-link-overrides-selectors: '.hds-button, .hds-link-standalone, .hds-link-inline, .hds-dropdown-list-item--variant-interactive > a, .hds-breadcrumb__link, .hds-tag__link, .hds-pagination-nav__control, .hds-side-nav__home-link, .hds-side-nav__icon-button, .hds-side-nav__list-item-link, .ember-a11y-refocus-skip-link';
+$cut-link-overrides-selectors: '.cut-link';

--- a/packages/pds-ember/app/styles/pds/components/link/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/__config.scss
@@ -65,7 +65,7 @@ $underline-width: 1px;
 
 @mixin apply {
   /* [debug] #{$_module}@apply */
-  :any-link:not(.pds-button, .cut-list-item > a.cut-list-item__content-container, #{overrides.$hds-link-overrides-selectors}) {
+  :any-link:not(.pds-button, #{overrides.$hds-link-overrides-selectors}, #{overrides.$cut-link-overrides-selectors}) {
     @content;
   }
 }

--- a/packages/pds-ember/app/styles/pds/components/link/__config.scss
+++ b/packages/pds-ember/app/styles/pds/components/link/__config.scss
@@ -65,7 +65,7 @@ $underline-width: 1px;
 
 @mixin apply {
   /* [debug] #{$_module}@apply */
-  :any-link:not(.pds-button, #{overrides.$hds-link-overrides-selectors}) {
+  :any-link:not(.pds-button, .cut-list-item > a.cut-list-item__content-container, #{overrides.$hds-link-overrides-selectors}) {
     @content;
   }
 }

--- a/packages/pds-ember/package.json
+++ b/packages/pds-ember/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashicorp/pds-ember",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Ember addon for building Structure-styled UIs",
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Adds the consul ui toolkit list item to the any-link override. 

Before:
<img width="1672" alt="Screenshot 2023-08-28 at 9 23 27 AM" src="https://github.com/hashicorp/structure/assets/5448834/8f09026e-9a31-4d5a-8892-7abff3972cf1">

After applying the class manually:
<img width="1672" alt="Screenshot 2023-08-28 at 9 24 41 AM" src="https://github.com/hashicorp/structure/assets/5448834/680b14d8-ab86-4de4-b082-2d7521d3f222">
